### PR TITLE
Use loader rather than hardcoded SerialPort connection

### DIFF
--- a/lib/adaptors/serialport.js
+++ b/lib/adaptors/serialport.js
@@ -57,21 +57,31 @@ util.inherits(Adaptor, EventEmitter);
  * @return {void}
  */
 Adaptor.prototype.open = function open(callback) {
-  this.serialport = new SerialPort(this.conn, {});
+  var self = this,
+      serialport = this.serialport = new SerialPort(this.conn, {});
 
-  this.debug("opening serial port");
+  self.debug("opening serial port");
 
-  this.serialport.on("open", function(error) {
+  function emit(name) {
+    return self.emit.bind(self, name);
+  }
+
+  serialport.on("open", function(error) {
     if (error) {
-      this.debug("error opening serial port: " + error);
+      self.debug("error opening serial port: " + error);
       callback(error);
       return;
     }
 
-    this.debug("opened serial port");
-    this.emit("open");
+    self.debug("opened serial port");
+    self.emit("open");
+
+    serialport.on("error", emit("error"));
+    serialport.on("close", emit("close"));
+    serialport.on("data", emit("data"));
+
     callback();
-  }.bind(this));
+  });
 };
 
 /**
@@ -96,5 +106,5 @@ Adaptor.prototype.write = function write(data, callback) {
  */
 Adaptor.prototype.onRead = function read(callback) {
   this.debug("adding data event handler");
-  this.serialport.on("data", callback);
+  this.on("data", callback);
 };

--- a/lib/sphero.js
+++ b/lib/sphero.js
@@ -1,11 +1,11 @@
 "use strict";
 
-var SerialPort = require("serialport").SerialPort,
-    util = require("util"),
+var util = require("util"),
     EventEmitter = require("events").EventEmitter,
     Packet = require("./packet");
 
-var coreDevice = require("./devices/core");
+var coreDevice = require("./devices/core"),
+    loader = require("./loader");
 
 var SOP2 = {
   answer: 0xFD,
@@ -20,7 +20,7 @@ var Sphero = function(address, opts) {
   opts = opts || {};
   this.ready = false;
   this.packet = new Packet();
-  this.connection = new SerialPort(address, {}, false);
+  this.connection = loader.load(address);
   this.callbacks = new Array(256);
   this.sop2Bitfield = SOP2[opts.sop2] || SOP2.answer;
   this.seqCounter = 0x00;
@@ -36,46 +36,44 @@ module.exports = function(address, options) {
 };
 
 Sphero.prototype.connect = function(callback) {
-  this.packet.on("error", function() {
-    this.emit("error");
-  }.bind(this));
+  var self = this,
+      connection = this.connection;
 
-  this.connection.open(function() {
-    this.ready = true;
+  function emit(name) {
+    return self.emit.bind(self, name);
+  }
 
-    this.connection.on("data", function(payload) {
+  this.packet.on("error", emit("error"));
 
-      this.emit("data", payload);
+  connection.open(function() {
+    self.ready = true;
 
-      var packet = this.packet.parse(payload);
+    connection.onRead(function(payload) {
+      self.emit("data", payload);
 
-      if (!!packet && packet.sop1) {
-        // this is a sync response package
+      var packet = self.packet.parse(payload);
+
+      if (packet && packet.sop1) {
         if (packet.sop2 === SOP2.sync) {
-          this.emit("response", packet);
-          this._execCallback(packet.seq, packet);
-        } else if (packet.sop2 === SOP2.async) { // this is an async response
-          this.emit("async", packet);
+          // synchronous packet
+          self.emit("response", packet);
+          self._execCallback(packet.seq, packet);
+        } else if (packet.sop2 === SOP2.async) {
+          // async packet
+          self.emit("async", packet);
         }
       }
-    }.bind(this));
+    });
 
-    this.connection.on("close", function(data) {
-      this.emit("close", data);
-    }.bind(this));
+    connection.on("close", emit("close"));
+    connection.on("error", emit("error"));
 
-    this.connection.on("error", function(err) {
-      this.emit("error", err);
-    }.bind(this));
+    connection.emit("ready");
 
     if (typeof callback === "function") {
       callback();
     }
-
-    this.ready = true;
-    this.emit("ready");
-
-  }.bind(this));
+  });
 };
 
 Sphero.prototype._incSeq = function() {

--- a/spec/lib/sphero.spec.js
+++ b/spec/lib/sphero.spec.js
@@ -1,22 +1,18 @@
 "use strict";
 
-var spheroFactory = lib("sphero");
+var factory = lib("sphero");
 
-var Packet = require("../../lib/packet"),
-    SerialPort = require("serialport").SerialPort;
+var Packet = lib("packet"),
+    SerialPort = lib("adaptors/serialport");
 
 describe("Sphero", function() {
   var sphero;
 
   beforeEach(function() {
-    sphero = spheroFactory("/dev/rfcomm0");
+    sphero = factory("/dev/rfcomm0");
   });
 
   describe("#constructor", function() {
-
-    beforeEach(function() {
-    });
-
     it("is not ready until #connect is called", function() {
       expect(sphero.ready).to.be.false;
     });


### PR DESCRIPTION
Some small refactors / modification of the Serialport adaptor while I was at it.

Using the `#onRead` method rather than directly listening to the `data` event, since I'm unsure if the same (or similar) is possible with BLE.
