### PR TITLE
Simplify core device, add #commandProxy helper

### DIFF
--- a/lib/devices/core.js
+++ b/lib/devices/core.js
@@ -5,111 +5,107 @@ var CORE_ADDR = 0x00;
 var utils = require("../utils"),
     commands = require("../commands/core");
 
-module.exports = function Core() {
-  var core;
+module.exports = function() {
+  var core = {};
 
-  core = {
-    coreCommand: function(cmdName, data, callback) {
-      this.command(CORE_ADDR, cmdName, data, callback);
-    },
+  var command = utils.commandProxy(core, CORE_ADDR);
 
-    ping: function(callback) {
-      this.coreCommand(commands.ping, null, callback);
-    },
+  core.ping = function(callback) {
+    command(commands.ping, null, callback);
+  };
 
-    version: function(callback) {
-      this.coreCommand(commands.version, null, callback);
-    },
+  core.version = function(callback) {
+    command(commands.version, null, callback);
+  };
 
-    controlUARTTx: function(callback) {
-      this.coreCommand(commands.controlUARTTx, null, callback);
-    },
+  core.controlUARTTx = function(callback) {
+    command(commands.controlUARTTx, null, callback);
+  };
 
-    setDeviceName: function(name, callback) {
-      var data = [];
+  core.setDeviceName = function(name, callback) {
+    var data = [];
 
-      for (var i = 0; i < name.length; ++i) {
-        data[i] = name.charCodeAt(i);
-      }
-
-      this.coreCommand(commands.setDeviceName, data, callback);
-    },
-
-    getBluetoothInfo: function(callback) {
-      this.coreCommand(commands.getBtInfo, null, callback);
-    },
-
-    setAutoReconnect: function(flag, time, callback) {
-      this.coreCommand(commands.setAutoReconnect, [flag, time], callback);
-    },
-
-    getAutoReconnect: function(callback) {
-      this.coreCommand(commands.getAutoReconnect, null, callback);
-    },
-
-    getPowerState: function(callback) {
-      this.coreCommand(commands.getPwrState, null, callback);
-    },
-
-    setPowerNotification: function(flag, callback) {
-      this.coreCommand(commands.setPwrNotify, [flag], callback);
-    },
-
-    sleep: function(wakeup, macro, orbBasic, callback) {
-      wakeup = utils.intToHexArray(wakeup, 2);
-      orbBasic = utils.intToHexArray(orbBasic, 2);
-
-      var data = [].concat(wakeup, macro, orbBasic);
-
-      this.coreCommand(commands.sleep, data, callback);
-    },
-
-    getVoltageTripPoints: function(callback) {
-      this.coreCommand(commands.getPowerTrips, null, callback);
-    },
-
-    setVoltageTripPoints: function(vLow, vCrit, callback) {
-      vLow = utils.intToHexArray(vLow, 2);
-      vCrit = utils.intToHexArray(vCrit, 2);
-
-      var data = [].concat(vLow, vCrit);
-
-      this.coreCommand(commands.setPowerTrips, data, callback);
-    },
-
-    setInactivityTimeout: function(time, callback) {
-      var data = utils.intToHexArray(time, 2);
-      this.coreCommand(commands.setInactiveTimer, data, callback);
-    },
-
-    jumpToBootloader: function(callback) {
-      this.coreCommand(commands.goToBl, null, callback);
-    },
-
-    runL1Diags: function(callback) {
-      this.coreCommand(commands.runL1Diags, null, callback);
-    },
-
-    runL2Diags: function(callback) {
-      this.coreCommand(commands.runL2Diags, null, callback);
-    },
-
-    clearCounters: function(callback) {
-      this.coreCommand(commands.clearCounters, null, callback);
-    },
-
-    _coreTimeCmd: function(cmd, time, callback) {
-      var data = utils.intToHexArray(time, 4);
-      this.coreCommand(cmd, data, callback);
-    },
-
-    assignTime: function(time, callback) {
-      this._coreTimeCmd(commands.assignTime, time, callback);
-    },
-
-    pollPacketTimes: function(time, callback) {
-      this._coreTimeCmd(commands.pollTimes, time, callback);
+    for (var i = 0; i < name.length; ++i) {
+      data[i] = name.charCodeAt(i);
     }
+
+    command(commands.setDeviceName, data, callback);
+  };
+
+  core.getBluetoothInfo = function(callback) {
+    command(commands.getBtInfo, null, callback);
+  };
+
+  core.setAutoReconnect = function(flag, time, callback) {
+    command(commands.setAutoReconnect, [flag, time], callback);
+  };
+
+  core.getAutoReconnect = function(callback) {
+    command(commands.getAutoReconnect, null, callback);
+  };
+
+  core.getPowerState = function(callback) {
+    command(commands.getPwrState, null, callback);
+  };
+
+  core.setPowerNotification = function(flag, callback) {
+    command(commands.setPwrNotify, [flag], callback);
+  };
+
+  core.sleep = function(wakeup, macro, orbBasic, callback) {
+    wakeup = utils.intToHexArray(wakeup, 2);
+    orbBasic = utils.intToHexArray(orbBasic, 2);
+
+    var data = [].concat(wakeup, macro, orbBasic);
+
+    command(commands.sleep, data, callback);
+  };
+
+  core.getVoltageTripPoints = function(callback) {
+    command(commands.getPowerTrips, null, callback);
+  };
+
+  core.setVoltageTripPoints = function(vLow, vCrit, callback) {
+    vLow = utils.intToHexArray(vLow, 2);
+    vCrit = utils.intToHexArray(vCrit, 2);
+
+    var data = [].concat(vLow, vCrit);
+
+    command(commands.setPowerTrips, data, callback);
+  };
+
+  core.setInactivityTimeout = function(time, callback) {
+    var data = utils.intToHexArray(time, 2);
+    command(commands.setInactiveTimer, data, callback);
+  };
+
+  core.jumpToBootloader = function(callback) {
+    command(commands.goToBl, null, callback);
+  };
+
+  core.runL1Diags = function(callback) {
+    command(commands.runL1Diags, null, callback);
+  };
+
+  core.runL2Diags = function(callback) {
+    command(commands.runL2Diags, null, callback);
+  };
+
+  core.clearCounters = function(callback) {
+    command(commands.clearCounters, null, callback);
+  };
+
+  core._coreTimeCmd = function(cmd, time, callback) {
+    var data = utils.intToHexArray(time, 4);
+    command(cmd, data, callback);
+  };
+
+  core.assignTime = function(time, callback) {
+    this._coreTimeCmd(commands.assignTime, time, callback);
+  };
+
+  core.pollPacketTimes = function(time, callback) {
+    this._coreTimeCmd(commands.pollTimes, time, callback);
   };
 
   return core;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -77,3 +77,17 @@ exports.argsToHexArray = function argsToArray() {
 
   return args;
 };
+
+/**
+ * A command proxy for Sphero virtual devices.
+ *
+ * @param {Object} context object on which `this.command` will be called
+ * @param {Number} address virtual device ID to prefix command calls with
+ * @return {Function} command function that will proxy to this.command
+ */
+exports.commandProxy = function commandProxy(context, address) {
+  return function command() {
+    var args = [].slice.call(arguments, 0);
+    context.command.apply(context, [address].concat(args));
+  };
+};

--- a/spec/lib/core.spec.js
+++ b/spec/lib/core.spec.js
@@ -9,164 +9,143 @@ describe("Core", function() {
     core = factory();
   });
 
-  describe("#coreCommand", function() {
-    var callback;
-
-    beforeEach(function() {
-      callback = spy();
-
-      core.command = stub();
-
-      core.coreCommand(0x01, null, callback);
-    });
-
-    it("calls #command with params", function() {
-      expect(core.command).to.be.calledOnce;
-      expect(core.command).to.be.calledWith(0x00, 0x01, null, callback);
-    });
-  });
-
   describe("commands", function() {
     var callback;
 
     beforeEach(function() {
       callback = spy();
-      stub(core, "coreCommand");
+      core.command = spy();
     });
 
-    afterEach(function() {
-      core.coreCommand.restore();
-    });
-
-    it("#ping calls #coreCommand with params", function() {
+    it("#ping calls #command with params", function() {
       core.ping(callback);
-      expect(core.coreCommand).to.be.calledOnce;
-      expect(core.coreCommand).to.be.calledWith(0x01, null, callback);
+      expect(core.command).to.be.calledOnce;
+      expect(core.command).to.be.calledWith(0x00, 0x01, null, callback);
     });
 
-    it("#version calls #coreCommand with params", function() {
+    it("#version calls #command with params", function() {
       core.version(callback);
-      expect(core.coreCommand).to.be.calledOnce;
-      expect(core.coreCommand).to.be.calledWith(0x02, null, callback);
+      expect(core.command).to.be.calledOnce;
+      expect(core.command).to.be.calledWith(0x00, 0x02, null, callback);
     });
 
-    it("#controlUARTTx calls #coreCommand with params", function() {
+    it("#controlUARTTx calls #command with params", function() {
       core.controlUARTTx(callback);
-      expect(core.coreCommand).to.be.calledOnce;
-      expect(core.coreCommand).to.be.calledWith(0x03, null, callback);
+      expect(core.command).to.be.calledOnce;
+      expect(core.command).to.be.calledWith(0x00, 0x03, null, callback);
     });
 
-    it("#setDeviceName calls #coreCommand with params", function() {
+    it("#setDeviceName calls #command with params", function() {
       core.setDeviceName("Esfiro", callback);
-      expect(core.coreCommand).to.be.calledOnce;
-      expect(core.coreCommand)
-        .to.be.calledWith(0x10, [69, 115, 102, 105, 114, 111], callback);
+      expect(core.command).to.be.calledOnce;
+      expect(core.command)
+        .to.be.calledWith(0x00, 0x10, [69, 115, 102, 105, 114, 111], callback);
     });
 
-    it("#getBluetoothInfo calls #coreCommand with params", function() {
+    it("#getBluetoothInfo calls #command with params", function() {
       core.getBluetoothInfo(callback);
-      expect(core.coreCommand).to.be.calledOnce;
-      expect(core.coreCommand).to.be.calledWith(0x11, null, callback);
+      expect(core.command).to.be.calledOnce;
+      expect(core.command).to.be.calledWith(0x00, 0x11, null, callback);
     });
 
-    it("#setAutoReconnect calls #coreCommand with params", function() {
+    it("#setAutoReconnect calls #command with params", function() {
       core.setAutoReconnect(0x01, 0x05, callback);
-      expect(core.coreCommand).to.be.calledOnce;
-      expect(core.coreCommand).to.be.calledWith(0x12, [0x01, 0x05], callback);
+      expect(core.command).to.be.calledOnce;
+      expect(core.command).to.be.calledWith(0x00, 0x12, [0x01, 0x05], callback);
     });
 
-    it("#getAutoReconnect calls #coreCommand with params", function() {
+    it("#getAutoReconnect calls #command with params", function() {
       core.getAutoReconnect(callback);
-      expect(core.coreCommand).to.be.calledOnce;
-      expect(core.coreCommand).to.be.calledWith(0x13, null, callback);
+      expect(core.command).to.be.calledOnce;
+      expect(core.command).to.be.calledWith(0x00, 0x13, null, callback);
     });
 
-    it("#getPowerState calls #coreCommand with params", function() {
+    it("#getPowerState calls #command with params", function() {
       core.getPowerState(callback);
-      expect(core.coreCommand).to.be.calledOnce;
-      expect(core.coreCommand).to.be.calledWith(0x20, null, callback);
+      expect(core.command).to.be.calledOnce;
+      expect(core.command).to.be.calledWith(0x00, 0x20, null, callback);
     });
 
-    it("#setPowerNotification calls #coreCommand with params", function() {
+    it("#setPowerNotification calls #command with params", function() {
       core.setPowerNotification(0x01, callback);
-      expect(core.coreCommand).to.be.calledOnce;
-      expect(core.coreCommand).to.be.calledWith(0x21, [0x01], callback);
+      expect(core.command).to.be.calledOnce;
+      expect(core.command).to.be.calledWith(0x00, 0x21, [0x01], callback);
     });
 
-    it("#sleep calls #coreCommand with params", function() {
+    it("#sleep calls #command with params", function() {
       core.sleep(256, 255, 256, callback);
-      expect(core.coreCommand).to.be.calledOnce;
-      expect(core.coreCommand)
-      .to.be.calledWith(0x22, [0x01, 0x00, 0xFF, 0x01, 0x00], callback);
+      expect(core.command).to.be.calledOnce;
+      expect(core.command)
+      .to.be.calledWith(0x00, 0x22, [0x01, 0x00, 0xFF, 0x01, 0x00], callback);
     });
 
-    it("#getVoltageTripPoints calls #coreCommand with params", function() {
+    it("#getVoltageTripPoints calls #command with params", function() {
       core.getVoltageTripPoints(callback);
-      expect(core.coreCommand).to.be.calledOnce;
-      expect(core.coreCommand).to.be.calledWith(0x23, null, callback);
+      expect(core.command).to.be.calledOnce;
+      expect(core.command).to.be.calledWith(0x00, 0x23, null, callback);
     });
 
-    it("#setVoltageTripPoints calls #coreCommand with params", function() {
+    it("#setVoltageTripPoints calls #command with params", function() {
       core.setVoltageTripPoints(0xFF00, 0x00FF, callback);
-      expect(core.coreCommand).to.be.calledOnce;
-      expect(core.coreCommand)
-        .to.be.calledWith(0x24, [0xFF, 0x00, 0x00, 0xFF], callback);
+      expect(core.command).to.be.calledOnce;
+      expect(core.command)
+        .to.be.calledWith(0x00, 0x24, [0xFF, 0x00, 0x00, 0xFF], callback);
     });
 
-    it("#setInactiveTimeout calls #coreCommand with params", function() {
+    it("#setInactiveTimeout calls #command with params", function() {
       core.setInactivityTimeout(0x0F, callback);
-      expect(core.coreCommand).to.be.calledOnce;
-      expect(core.coreCommand)
-        .to.be.calledWith(0x25, [0x00, 0x0F], callback);
+      expect(core.command).to.be.calledOnce;
+      expect(core.command)
+        .to.be.calledWith(0x00, 0x25, [0x00, 0x0F], callback);
     });
 
-    it("#jumpToBotloader calls #coreCommand with params", function() {
+    it("#jumpToBotloader calls #command with params", function() {
       core.jumpToBootloader(callback);
-      expect(core.coreCommand).to.be.calledOnce;
-      expect(core.coreCommand)
-        .to.be.calledWith(0x30, null, callback);
+      expect(core.command).to.be.calledOnce;
+      expect(core.command)
+        .to.be.calledWith(0x00, 0x30, null, callback);
     });
 
-    it("#runL1Diags calls #coreCommand with params", function() {
+    it("#runL1Diags calls #command with params", function() {
       core.runL1Diags(callback);
-      expect(core.coreCommand).to.be.calledOnce;
-      expect(core.coreCommand)
-        .to.be.calledWith(0x40, null, callback);
+      expect(core.command).to.be.calledOnce;
+      expect(core.command)
+        .to.be.calledWith(0x00, 0x40, null, callback);
     });
 
-    it("#runL2Diags calls #coreCommand with params", function() {
+    it("#runL2Diags calls #command with params", function() {
       core.runL2Diags(callback);
-      expect(core.coreCommand).to.be.calledOnce;
-      expect(core.coreCommand)
-        .to.be.calledWith(0x41, null, callback);
+      expect(core.command).to.be.calledOnce;
+      expect(core.command)
+        .to.be.calledWith(0x00, 0x41, null, callback);
     });
 
-    it("#clearCounters calls #coreCommand with params", function() {
+    it("#clearCounters calls #command with params", function() {
       core.clearCounters(callback);
-      expect(core.coreCommand).to.be.calledOnce;
-      expect(core.coreCommand)
-        .to.be.calledWith(0x42, null, callback);
+      expect(core.command).to.be.calledOnce;
+      expect(core.command)
+        .to.be.calledWith(0x00, 0x42, null, callback);
     });
 
-    it("#_coreTimeCmd calls #coreCommand with params", function() {
+    it("#_coreTimeCmd calls #command with params", function() {
       core._coreTimeCmd(0x50, 0xFF, callback);
-      expect(core.coreCommand).to.be.calledOnce;
-      expect(core.coreCommand)
-        .to.be.calledWith(0x50, [0x00, 0x00, 0x00, 0xFF], callback);
+      expect(core.command).to.be.calledOnce;
+      expect(core.command)
+        .to.be.calledWith(0x00, 0x50, [0x00, 0x00, 0x00, 0xFF], callback);
     });
 
     it("#assignTime calls #_coreTimeCmd with params", function() {
       core.assignTime(0xFF, callback);
-      expect(core.coreCommand).to.be.calledOnce;
-      expect(core.coreCommand)
-        .to.be.calledWith(0x50, [0x00, 0x00, 0x00, 0xFF], callback);
+      expect(core.command).to.be.calledOnce;
+      expect(core.command)
+        .to.be.calledWith(0x00, 0x50, [0x00, 0x00, 0x00, 0xFF], callback);
     });
 
     it("#pollPacketTimes calls #_coreTimeCmd with params", function() {
       core.pollPacketTimes(0xFF, callback);
-      expect(core.coreCommand).to.be.calledOnce;
-      expect(core.coreCommand)
-        .to.be.calledWith(0x51, [0x00, 0x00, 0x00, 0xFF], callback);
+      expect(core.command).to.be.calledOnce;
+      expect(core.command)
+        .to.be.calledWith(0x00, 0x51, [0x00, 0x00, 0x00, 0xFF], callback);
     });
   });
 });

--- a/spec/lib/utils.spec.js
+++ b/spec/lib/utils.spec.js
@@ -46,4 +46,27 @@ describe("utils", function() {
       expect(utils.intToHexArray(65535, 2)).to.be.eql([0xFF, 0xFF]);
     });
   });
+
+  describe("#commandProxy", function() {
+    var address = 0x10,
+        context;
+
+    beforeEach(function() {
+      context = { command: spy() };
+    });
+
+    it("proxies commands to the provided context", function() {
+      var proxy = utils.commandProxy(context, address),
+          callback = spy();
+
+      proxy(0x1A, "hello there!", callback);
+
+      expect(context.command).to.be.calledWith(
+        address,
+        0x1A,
+        "hello there!",
+        callback
+      );
+    });
+  });
 });


### PR DESCRIPTION
I would have just used `Function#bind` - but when these factories are called, `core` doesn't have a `command` function.

Perhaps a better solution for adding this (device) behaviour is simply to switch from a factory to a mutator pattern?

So we'd pass in a Sphero object to the device function, and it would add functions as necessary directly onto the Sphero object.

e.g.

``` javascript
// lib/sphero.js

var core = require("./devices/core"),
    sphero = require("./devices/sphero");

var Sphero = function Sphero(address, opts) {
  // stuff
  core(this);
  sphero(this);
}

Sphero.prototype.command = function(device, command, data, callback) {
  // command stuff
}
```

---

``` javascript
// lib/devices/core.js

var utils = require("../utils"),
    commands = require("../commands/core");

module.exports = function core(device) {
  var command = device.command.bind(device, 0x00);

  // append methods to the device we were given by `lib/sphero.js`
  device.ping = function(callback) {
    command(commands.ping, null, callback);
  };
};
```

Greatly simplifies extra work we need to do (gets rid of `Sphero#_bindDevice`, `coreCommand`, etc).

If this seems a better idea, I can close this PR and implement that version instead.
