### PR TITLE
Fixes connection error handling

### DIFF
--- a/lib/adaptors/serialport.js
+++ b/lib/adaptors/serialport.js
@@ -50,13 +50,13 @@ util.inherits(Adaptor, EventEmitter);
  */
 Adaptor.prototype.open = function open(callback) {
   var self = this,
-      port = this.serialport = new serialport.SerialPort(this.conn, {});
+      port = this.serialport = new serialport.SerialPort(this.conn, {}, false);
 
   function emit(name) {
     return self.emit.bind(self, name);
   }
 
-  port.on("open", function(error) {
+  port.open(function(error) {
     if (error) {
       callback(error);
       return;

--- a/lib/sphero.js
+++ b/lib/sphero.js
@@ -89,7 +89,11 @@ Sphero.prototype.connect = function(callback) {
 
   connection.on("open", emit("open"));
 
-  connection.open(function() {
+  connection.open(function(error) {
+    if(error) {
+      callback(error);
+      return;
+    }
     self.ready = true;
 
     connection.onRead(function(payload) {


### PR DESCRIPTION
Before, when initialising serial port, it was defaulting to open immediately, which was using its own callback that emitted an error when there was one. serialport.js looks like it was trying to give a callback of its own but the open event never passes a value.

I have set serialport to not open immediately, and corrected the open line such that an error will be passed to the callback. Then I added error handling to the sphero connect function such that an error is passed to whatever calls connect.

This now means that connect's callback isn't only called on a successful connection. This could be avoided by properly catching and emitting the error events such that a orb.on('error'... will catch them.