### PR TITLE
Fixes serialport install on mac machines

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "sphero",
   "version": "0.3.0",
+  "main": "index",
   "description": "Sphero.js",
   "homepage": "http://gosphero.com",
   "bugs": "https://github.com/orbotix/sphero.js/issues",
@@ -38,7 +39,7 @@
   },
 
   "dependencies": {
-    "serialport": "1.7.1",
+    "serialport": "2.0.0",
     "browser-serialport": "2.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
 
   "dependencies": {
-    "serialport": "2.0.0",
+    "serialport": "^2.0.0",
     "browser-serialport": "2.0.2"
   }
 }


### PR DESCRIPTION
The version of serialport sphero.js currently uses (1.7.1) does not install properly on macs due to conflicts with xcode tools. Using serialport 2.0.0 or above fixes this.