### PR TITLE
Better named colour check - Fixes #24

### DIFF
--- a/lib/devices/custom.js
+++ b/lib/devices/custom.js
@@ -95,7 +95,7 @@ module.exports = function custom(device) {
         break;
 
       case "string":
-        if (colors[color]) {
+        if (colors.hasOwnProperty(color)) {
           color = hexToRgb(colors[color]);
           break;
         }


### PR DESCRIPTION
Fixes #24 

'black' was coming back falsey and being read as invalid.

Now this checks for the property rather than the value being truthy.

I'm not familiar with Mocha but maybe we could loop through the colour list and check they all work in the tests?