### PR TITLE
Allow passing in a valid preexisting but unconnected Noble peripheral

### DIFF
--- a/lib/adaptors/ble.js
+++ b/lib/adaptors/ble.js
@@ -3,31 +3,34 @@
 var util = require("util"),
     EventEmitter = require("events").EventEmitter;
 
-var ble,
-    isChrome = typeof chrome !== "undefined";
+var ble;
 
-// thanks to https://github.com/jgautier/firmata/blob/master/lib/firmata.js
-try {
-  if (isChrome) {
-    // browser BLE interface here...
-  } else {
-    ble = require("noble");
+function initBLE() {
+  var isChrome = typeof chrome !== "undefined";
+
+  // thanks to https://github.com/jgautier/firmata/blob/master/lib/firmata.js
+  try {
+    if (isChrome) {
+      // browser BLE interface here...
+    } else {
+      ble = require("noble");
+    }
+  } catch (error) {
+    ble = null;
   }
-} catch (error) {
-  ble = null;
-}
 
-if (ble == null) {
-  var err = [
-    "It looks like you want to connect to a Sphero BB-8 or Sphero Ollie,",
-    "but did not install the 'noble' module.", "",
-    "To install it run this command:",
-    "npm install noble", "",
-    "For more information go to https://github.com/sandeepmistry/noble"
-  ].join("\n");
+  if (ble == null) {
+    var err = [
+      "It looks like you want to connect to a Sphero BB-8 or Sphero Ollie,",
+      "but did not install the 'noble' module.", "",
+      "To install it run this command:",
+      "npm install noble", "",
+      "For more information go to https://github.com/sandeepmistry/noble"
+    ].join("\n");
 
-  console.error(err);
-  throw new Error("Missing noble dependency");
+    console.error(err);
+    throw new Error("Missing noble dependency");
+  }
 }
 
 /**
@@ -36,13 +39,18 @@ if (ble == null) {
  * @constructor
  * @param {String} peripheralId the BLE address to connect to
  * @param {Object} options optional parameters
+ * @param {Object} [options.peripheral=object] use an existing Noble peripheral
  */
 var Adaptor = module.exports = function Adaptor(peripheralId, options) {
   var uuid = peripheralId.split(":").join("").toLowerCase();
   this.uuid = uuid;
   var opts = options || {};
   this.noblePeripheral = opts.peripheral;
-  this.peripheral = null;
+  if (this.noblePeripheral) {
+    ble = this.noblePeripheral._noble;
+  } else {
+    initBLE();
+  }
   this.connectedPeripherals = {};
   this.isConnected = false;
   this.readHandler = function() {

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -9,9 +9,11 @@ function isSerialPort(str) {
  * Loads an adaptor based on provided connection string and system state
  *
  * @param {String} conn connection string (serial port or BLE UUID)
+ * @param {Object} opts for loader
+ * @param {Object} [opts.peripheral=object] use an existing Noble peripheral
  * @return {Object} adaptor instance
  */
-module.exports.load = function load(conn) {
+module.exports.load = function load(conn, opts) {
   var isSerial = isSerialPort(conn),
       isChrome = typeof chrome !== "undefined",
       Adaptor;
@@ -24,5 +26,5 @@ module.exports.load = function load(conn) {
     Adaptor = require("./adaptors/ble");
   }
 
-  return new Adaptor(conn);
+  return new Adaptor(conn, opts);
 };

--- a/lib/sphero.js
+++ b/lib/sphero.js
@@ -35,6 +35,7 @@ function classCallCheck(instance, Constructor) {
  * @param {Number} [opts.sop2=0xFD] sop2 to be passed to commands
  * @param {Number} [opts.timeout=500] deadtime between commands, in ms
  * @param {Boolean} [opts.emitPacketErrors=false] emit events on packet errors
+ * @param {Object} [opts.peripheral=object] use an existing Noble peripheral
  * @example
  * var orb = new Sphero("/dev/rfcomm0", { timeout: 300 });
  * @returns {Sphero} a new instance of Sphero
@@ -48,7 +49,7 @@ var Sphero = module.exports = function Sphero(address, opts) {
   this.busy = false;
   this.ready = false;
   this.packet = new Packet();
-  this.connection = opts.adaptor || loader.load(address);
+  this.connection = opts.adaptor || loader.load(address, opts);
   this.callbackQueue = [];
   this.commandQueue = [];
   this.sop2Bitfield = SOP2[opts.sop2] || SOP2.both;


### PR DESCRIPTION
Allow passing in a valid preexisting but unconnected Noble peripheral, and do not require the Noble module a second time when this happens, to avoid re-initialization.

