### PR TITLE
Only use Noble's own cache of services and characteristics

### DIFF
--- a/lib/adaptors/ble.js
+++ b/lib/adaptors/ble.js
@@ -39,7 +39,6 @@ function initBLE() {
  * @constructor
  * @param {String} peripheralId the BLE address to connect to
  * @param {Object} options optional parameters
- * @param {Object} [options.peripheral=object] use an existing Noble peripheral
  */
 var Adaptor = module.exports = function Adaptor(peripheralId, options) {
   var uuid = peripheralId.split(":").join("").toLowerCase();
@@ -51,6 +50,7 @@ var Adaptor = module.exports = function Adaptor(peripheralId, options) {
   } else {
     initBLE();
   }
+  this.peripheral = null;
   this.connectedPeripherals = {};
   this.isConnected = false;
   this.readHandler = function() {
@@ -318,10 +318,11 @@ Adaptor.prototype._connectPeripheral = function(np, callback) {
 };
 
 Adaptor.prototype._connectBLE = function(callback) {
-  if (this.isConnected) {
+  var p = this._connectedPeripheral();
+
+  if (p.state === "connected") {
     callback();
   } else {
-    var p = this._connectedPeripheral();
     var self = this;
     p.connect(function() {
       self.isConnected = true;
@@ -333,17 +334,13 @@ Adaptor.prototype._connectBLE = function(callback) {
 Adaptor.prototype._connectService = function(serviceId, callback) {
   var self = this;
   var p = this._connectedPeripheral();
-  if (Object.keys(this._connectedServices()).length > 0) {
+  if (this._connectedServices()) {
     callback(null, self._connectedService(serviceId));
   } else {
     p.discoverServices(null, function(serErr, services) {
       if (serErr) { return callback(serErr); }
 
       if (services.length > 0) {
-        for (var s in services) {
-          self._addConnectedService(services[s]);
-        }
-
         var service = self._connectedService(serviceId);
         callback(null, service);
       } else {
@@ -357,7 +354,7 @@ Adaptor.prototype._connectCharacteristic = function(serviceId,
                                                     characteristicId,
                                                     callback) {
   var self = this;
-  if (Object.keys(self._connectedCharacteristics(serviceId)).length > 0) {
+  if (self._connectedCharacteristics(serviceId)) {
     callback(null, self._connectedCharacteristic(serviceId, characteristicId));
   } else {
     var s = self._connectedService(serviceId);
@@ -366,10 +363,6 @@ Adaptor.prototype._connectCharacteristic = function(serviceId,
       if (charErr) { return callback(charErr); }
 
       if (characteristics.length > 0) {
-        for (var c in characteristics) {
-          self._addConnectedCharacteristic(serviceId, characteristics[c]);
-        }
-
         var characteristic = self._connectedCharacteristic(serviceId,
                                                            characteristicId);
         callback(null, characteristic);
@@ -387,34 +380,37 @@ Adaptor.prototype._connectedPeripheral = function() {
 
 // services helpers
 Adaptor.prototype._connectedServices = function() {
-  if (!this.isConnected) {
+  var p = this._connectedPeripheral();
+
+  if (p.state !== "connected") {
     return null;
   }
 
-  return this.connectedPeripherals[this.uuid].services;
+  return p.services;
 };
 
 Adaptor.prototype._connectedService = function(serviceId) {
-  return this._connectedServices()[serviceId].service;
-};
-
-Adaptor.prototype._addConnectedService = function(service) {
-  this._connectedServices()[service.uuid] = {service: service, characteristics: {}};
+  var services = this._connectedServices();
+  for (var s in services) {
+    if (services[s].uuid === serviceId) {
+      return services[s];
+    }
+  }
+  return null;
 };
 
 // characteristics helpers
 Adaptor.prototype._connectedCharacteristics = function(serviceId) {
-  if (!this.isConnected) {
-    return null;
-  }
-
-  return this._connectedServices()[serviceId].characteristics;
+  return this._connectedService(serviceId).characteristics;
 };
 
-Adaptor.prototype._addConnectedCharacteristic = function(serviceId, characteristic) {
-  this._connectedCharacteristics(serviceId)[characteristic.uuid] = characteristic;
-};
 
 Adaptor.prototype._connectedCharacteristic = function(serviceId, characteristicId) {
-  return this._connectedCharacteristics(serviceId)[characteristicId];
+  var characteristics = this._connectedCharacteristics(serviceId);
+  for (var c in characteristics) {
+    if (characteristics[c].uuid === characteristicId) {
+      return characteristics[c];
+    }
+  }
+  return null;
 };


### PR DESCRIPTION
Only use Noble's own cache of services and characteristics, cause that is all you need anyhow. In addition, allows for Noble connection sharing across modules.