### PR TITLE
Fixes connection error handling (cleaner PR)

### DIFF
--- a/lib/adaptors/serialport.js
+++ b/lib/adaptors/serialport.js
@@ -52,13 +52,13 @@ util.inherits(Adaptor, EventEmitter);
  */
 Adaptor.prototype.open = function open(callback) {
   var self = this,
-      port = this.serialport = new serialport.SerialPort(this.conn, {});
+      port = this.serialport = new serialport.SerialPort(this.conn, {}, false);
 
   function emit(name) {
     return self.emit.bind(self, name);
   }
 
-  port.on("open", function(error) {
+  port.open(function(error) {
     if (error) {
       callback(error);
       return;

--- a/lib/devices/core.js
+++ b/lib/devices/core.js
@@ -192,7 +192,36 @@ module.exports = function core(device) {
    * @return {void}
    */
   device.getPowerState = function(callback) {
-    command(commands.getPwrState, null, callback);
+    command(commands.getPwrState, null, function(err, data) {
+      if (err) { return callback(err); }
+      var batteryState = "";
+      switch (data.data[1]) {
+        case 0x01:
+          batteryState = "Charging";
+          break;
+      }
+      if (data.data[1] === 0x01) {
+        batteryState = "Charging";
+      } else if (data.data[1] === 0x02) {
+        batteryState = "OK";
+      } else if (data.data[1] === 0x03) {
+        batteryState = "Low";
+      } else if (data.data[1] === 0x04) {
+        batteryState = "Critical";
+      }
+
+      var batteryVoltage = data.data.slice(2, 4).readUInt16BE(0) / 100;
+      var numCharges = parseInt(data.data[4], 16);
+      var obj = {
+        recVer: data.data[0],
+        batteryState: data.data[1],
+        batteryStateS: batteryState,
+        batteryVoltage: batteryVoltage,
+        chargeCount: numCharges,
+        secondsSinceCharge: data.data[4],
+      };
+      callback(null, obj);
+    });
   };
 
   /**

--- a/lib/sphero.js
+++ b/lib/sphero.js
@@ -92,7 +92,11 @@ Sphero.prototype.connect = function(callback) {
 
   connection.on("open", emit("open"));
 
-  connection.open(function() {
+  connection.open(function(error) {
+    if (error) {
+      callback(error);
+      return;
+    }
     self.ready = true;
 
     connection.onRead(function(payload) {


### PR DESCRIPTION
- apply #30 changes on a fresh branch
- fix lint errors

But still failing 2 tests...
```
$ grunt
Running "lint" task

lib/adaptors/ble.js
  160:31  warning  Too many nested callbacks (4). Maximum allowed is 3  max-nested-callbacks
  162:23  warning  Too many nested callbacks (5). Maximum allowed is 3  max-nested-callbacks
  167:25  warning  Too many nested callbacks (5). Maximum allowed is 3  max-nested-callbacks
  408:0   warning  Line 408 exceeds the maximum line length of 80       max-len

lib/adaptors/serialport.js
  26:0  warning  Line 26 exceeds the maximum line length of 80  max-len

spec/lib/packet.spec.js
  685:0  warning  Line 685 exceeds the maximum line length of 80  max-len

✖ 6 problems (0 errors, 6 warnings)

Running "test" task


  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․

  271 passing (715ms)
  1 pending
  2 failing

  1) Serialport Adaptor #open "before each" hook:
     TypeError: port.open is not a function
      at Adaptor.open (lib/adaptors/serialport.js:61:8)
      at Context.<anonymous> (spec/lib/adaptors/serialport.spec.js:41:15)

  2) Core commands #getPowerState calls #command with params:
     AssertionError: expected command to have been called with arguments 0, 32, null, function spy() {}
    command(0, 32, null, function () {})
      at Context.<anonymous> (spec/lib/devices/core.spec.js:66:34)



Warning: Task "test" failed. Use --force to continue.

Aborted due to warnings.
```
