### PR TITLE
Handle error when the connecttion to the sphero fail

### DIFF
--- a/lib/adaptors/serialport.js
+++ b/lib/adaptors/serialport.js
@@ -72,6 +72,8 @@ Adaptor.prototype.open = function open(callback) {
 
     callback();
   });
+
+  port.on("error", emit("error"));
 };
 
 /**

--- a/lib/sphero.js
+++ b/lib/sphero.js
@@ -92,6 +92,8 @@ Sphero.prototype.connect = function(callback) {
 
   connection.on("open", emit("open"));
 
+  connection.on("error", emit("error"));
+
   connection.open(function() {
     self.ready = true;
 


### PR DESCRIPTION
Before that, when we did "orb.connect()", if it failed it throws an error that we could not handle.

Now we are able to do "orb.on("error", function() { // Do something });". We can handle the error.