### PR TITLE
Turn off the main LED off when calibrating Sphero

### DIFF
--- a/lib/devices/custom.js
+++ b/lib/devices/custom.js
@@ -264,8 +264,13 @@ module.exports = function custom(device) {
    * @return {void}
    */
   device.startCalibration = function(callback) {
-    device.setBackLed(127);
-    device.setStabilization(0, callback);
+    device.originalColor = 0;
+    device.getColor(function(data) {
+      device.originalColor = data.color;
+      device.setRgbLed(0);
+      device.setBackLed(127);
+      device.setStabilization(0, callback);
+    });
   };
 
   /**
@@ -281,6 +286,7 @@ module.exports = function custom(device) {
   device.finishCalibration = function(callback) {
     device.setHeading(0);
     device.setBackLed(0);
+    device.setRgbLed(device.originalColor);
     device.setStabilization(1, callback);
   };
 

--- a/lib/devices/custom.js
+++ b/lib/devices/custom.js
@@ -265,7 +265,11 @@ module.exports = function custom(device) {
    */
   device.startCalibration = function(callback) {
     device.originalColor = 0;
-    device.getColor(function(data) {
+    device.getColor(function(err, data) {
+      if (err) {
+        callback(err, null);
+      }
+
       device.originalColor = data.color;
       device.setRgbLed(0);
       device.setBackLed(127);

--- a/spec/lib/devices/custom.spec.js
+++ b/spec/lib/devices/custom.spec.js
@@ -148,7 +148,7 @@ describe("Custom Device Functions", function() {
     beforeEach(function() {
       device.setStabilization = spy();
       device.setBackLed = stub();
-      device.getColor = stub().yields({color: 0xff00ff});
+      device.getColor = stub().yields(null, {color: 0xff00ff});
 
       device.startCalibration();
     });

--- a/spec/lib/devices/custom.spec.js
+++ b/spec/lib/devices/custom.spec.js
@@ -148,6 +148,7 @@ describe("Custom Device Functions", function() {
     beforeEach(function() {
       device.setStabilization = spy();
       device.setBackLed = stub();
+      device.getColor = stub().yields({color: 0xff00ff});
 
       device.startCalibration();
     });
@@ -159,6 +160,10 @@ describe("Custom Device Functions", function() {
     it("turns on the back LED", function() {
       expect(device.setBackLed).to.be.calledWith(127);
     });
+
+    it("turns off the main LED", function() {
+      expect(device.setRgbLed).to.be.calledWith(0);
+    });
   });
 
   describe("#finishCalibration", function() {
@@ -166,6 +171,7 @@ describe("Custom Device Functions", function() {
       device.setStabilization = spy();
       device.setHeading = spy();
       device.setBackLed = stub();
+      device.setRgbLed = stub();
 
       device.finishCalibration();
     });
@@ -180,6 +186,10 @@ describe("Custom Device Functions", function() {
 
     it("turns off the back LED", function() {
       expect(device.setBackLed).to.be.calledWith(0);
+    });
+
+    it("turns on the main LED again using original color", function() {
+      expect(device.setRgbLed).to.be.calledWith(0xff00ff);
     });
   });
 


### PR DESCRIPTION
Turns the main LED off when calibrating Sphero, and then turns it back on and sets back to the original color once the calibration is complete.