### PR TITLE
Add optional luminance to color command

### DIFF
--- a/examples/luminance.js
+++ b/examples/luminance.js
@@ -1,0 +1,51 @@
+"use strict";
+
+var sphero = require("../");
+var orb = sphero(process.env.PORT);
+
+orb.connect(function() {
+  // sets color to the provided r/g/b values
+  orb.color({ red: 255, green: 0, blue: 255 });
+
+  setTimeout(function() {
+    console.log("color 1 - 50%");
+    // sets color to the provided hex value, at 50% luminance
+    orb.color(0xff0000, 50);
+  }, 1000);
+
+  setTimeout(function() {
+    console.log("color 1 - 100%");
+    // sets color to the same hex value, at 100% luminance
+    orb.color(0xff0000, 100);
+  }, 2000);
+
+  setTimeout(function() {
+    console.log("color 2 - 33%");
+    // hex numbers can also be passed in strings
+    orb.color("00ff00", 33);
+  }, 3000);
+
+  setTimeout(function() {
+    console.log("color 2 - 100%");
+    // hex numbers can also be passed in strings
+    orb.color("00ff00", 100);
+  }, 4000);
+
+  setTimeout(function() {
+    console.log("color 3 - 75%");
+    // sets color to the provided color name
+    orb.color("magenta", 75);
+  }, 5000);
+
+  setTimeout(function() {
+    console.log("color 3 - 0%");
+    // sets color to the provided color name
+    orb.color("magenta", 0);
+  }, 6000);
+
+  setTimeout(function() {
+    console.log("color 3 - 100%");
+    // sets color to the provided color name
+    orb.color("magenta", 100);
+  }, 7000);
+});

--- a/examples/luminance.js
+++ b/examples/luminance.js
@@ -8,44 +8,56 @@ orb.connect(function() {
   orb.color({ red: 255, green: 0, blue: 255 });
 
   setTimeout(function() {
-    console.log("color 1 - 50%");
-    // sets color to the provided hex value, at 50% luminance
-    orb.color(0xff0000, 50);
+    console.log("color 1 -50% luminance");
+    // sets color to the provided hex value, at -50% luminance
+    orb.color(0xcc0000, -0.5);
   }, 1000);
 
   setTimeout(function() {
-    console.log("color 1 - 100%");
-    // sets color to the same hex value, at 100% luminance
-    orb.color(0xff0000, 100);
+    console.log("color 1 normal% luminance");
+    // sets color to the same hex value, at +50% luminance
+    orb.color(0xcc0000, 0);
   }, 2000);
 
   setTimeout(function() {
-    console.log("color 2 - 33%");
-    // hex numbers can also be passed in strings
-    orb.color("00ff00", 33);
+    console.log("color 1 +50% luminance");
+    // sets color to the same hex value, at +50% luminance
+    orb.color(0xcc0000, 0.5);
   }, 3000);
 
   setTimeout(function() {
-    console.log("color 2 - 100%");
+    console.log("color 2 -50% luminance");
     // hex numbers can also be passed in strings
-    orb.color("00ff00", 100);
+    orb.color("00cc00", -0.5);
   }, 4000);
 
   setTimeout(function() {
-    console.log("color 3 - 75%");
-    // sets color to the provided color name
-    orb.color("magenta", 75);
+    console.log("color 2 normal% luminance");
+    // hex numbers can also be passed in strings
+    orb.color("00cc00", 0);
   }, 5000);
 
   setTimeout(function() {
-    console.log("color 3 - 0%");
-    // sets color to the provided color name
-    orb.color("magenta", 0);
+    console.log("color 2 +50% luminance");
+    // hex numbers can also be passed in strings
+    orb.color("00cc00", 0.5);
   }, 6000);
 
   setTimeout(function() {
-    console.log("color 3 - 100%");
+    console.log("color 3 -50% luminance");
     // sets color to the provided color name
-    orb.color("magenta", 100);
+    orb.color("magenta", -0.5);
   }, 7000);
+
+  setTimeout(function() {
+    console.log("color 3 normal% luminance");
+    // sets color to the provided color name
+    orb.color("magenta", 0);
+  }, 8000);
+
+  setTimeout(function() {
+    console.log("color 3 +50% luminance");
+    // sets color to the provided color name
+    orb.color("magenta", 0.5);
+  }, 9000);
 });

--- a/lib/devices/custom.js
+++ b/lib/devices/custom.js
@@ -26,8 +26,19 @@ function hexToRgb(num) {
 }
 
 /**
- * Converts a hex color number to RGB values,
- * adjusted by the relative luminance
+ * Converts a hex color number to luminance adjusted value
+ *
+ * @private
+ * @param {Object} hex hex color value to convert
+ * @param {Number} lum percentage of luminance
+ * @return {Object} converted color value
+ */
+function calculateLuminance(hex, lum) {
+  return Math.round(Math.min(Math.max(0, hex + (hex * lum)), 255));
+}
+
+/**
+ * Adjusts an RGB color by the relative luminance
  *
  * @private
  * @param {Object} rgb rgb color value to convert
@@ -35,18 +46,10 @@ function hexToRgb(num) {
  * @return {Object} RGB color values
  */
 function adjustLuminance(rgb, lum) {
-  var lp = lum / 100;
-
-  // calculate the full luminance
-  var yr = rgb.red * 0.33;
-  var yg = rgb.green * 0.5;
-  var yb = rgb.blue * 0.16;
-
-  // adjust to lum %
   var newRgb = {};
-  newRgb.red = Math.round(yr * lp / 0.33);
-  newRgb.green = Math.round(yg * lp / 0.5);
-  newRgb.blue = Math.round(yb * lp / 0.16);
+  newRgb.red = calculateLuminance(rgb.red, lum);
+  newRgb.green = calculateLuminance(rgb.green, lum);
+  newRgb.blue = calculateLuminance(rgb.blue, lum);
 
   return newRgb;
 }

--- a/lib/devices/custom.js
+++ b/lib/devices/custom.js
@@ -25,6 +25,32 @@ function hexToRgb(num) {
   };
 }
 
+/**
+ * Converts a hex color number to RGB values,
+ * adjusted by the relative luminance
+ *
+ * @private
+ * @param {Object} rgb rgb color value to convert
+ * @param {Number} lum percentage of luminance
+ * @return {Object} RGB color values
+ */
+function adjustLuminance(rgb, lum) {
+  var lp = lum / 100;
+
+  // calculate the full luminance
+  var yr = rgb.red * 0.33;
+  var yg = rgb.green * 0.5;
+  var yb = rgb.blue * 0.16;
+
+  // adjust to lum %
+  var newRgb = {};
+  newRgb.red = Math.round(yr * lp / 0.33);
+  newRgb.green = Math.round(yg * lp / 0.5);
+  newRgb.blue = Math.round(yb * lp / 0.16);
+
+  return newRgb;
+}
+
 module.exports = function custom(device) {
   function mergeMasks(id, mask, remove) {
     if (remove) {
@@ -73,6 +99,7 @@ module.exports = function custom(device) {
    * a greater range of possible inputs.
    *
    * @param {Number|String|Object} color what color to change Sphero to
+   * @param {string} [luminance] - percentage of luminance to apply to RGB color
    * @param {Function} callback function to be triggered with response
    * @example
    * orb.color("#00ff00", function(err, data) {
@@ -88,7 +115,8 @@ module.exports = function custom(device) {
    * });
    * @return {void}
    */
-  device.color = function(color, callback) {
+  device.color = function(color, luminance, callback) {
+    var cb = callback;
     switch (typeof color) {
       case "number":
         color = hexToRgb(color);
@@ -128,7 +156,13 @@ module.exports = function custom(device) {
         break;
     }
 
-    device.setRgbLed(color, callback);
+    if (typeof luminance === "function") {
+      cb = luminance;
+    } else if (typeof luminance === "number") {
+      color = adjustLuminance(color, luminance);
+    }
+
+    device.setRgbLed(color, cb);
   };
 
   /**

--- a/spec/lib/devices/custom.spec.js
+++ b/spec/lib/devices/custom.spec.js
@@ -82,6 +82,26 @@ describe("Custom Device Functions", function() {
         expect(rgb).to.be.calledWithMatch({ red: 250, green: 10, blue: 125 });
       });
     });
+
+    context("with luminance", function() {
+      it("converts to an RGB object at 50%", function() {
+        device.color(0xc3FF00, 50);
+        var color = { red: 98, blue: 0, green: 128 };
+        expect(rgb).to.be.calledWith(color);
+      });
+
+      it("converts to an RGB object at 33%", function() {
+        device.color(0xc3FF00, 33);
+        var color = { red: 64, blue: 0, green: 84 };
+        expect(rgb).to.be.calledWith(color);
+      });
+
+      it("converts to an RGB object at 100%", function() {
+        device.color(0xc3FF00, 100);
+        var color = { red: 195, blue: 0, green: 255 };
+        expect(rgb).to.be.calledWith(color);
+      });
+    });
   });
 
   describe("#randomColor", function() {

--- a/spec/lib/devices/custom.spec.js
+++ b/spec/lib/devices/custom.spec.js
@@ -84,21 +84,21 @@ describe("Custom Device Functions", function() {
     });
 
     context("with luminance", function() {
-      it("converts to an RGB object at 50%", function() {
-        device.color(0xc3FF00, 50);
-        var color = { red: 98, blue: 0, green: 128 };
+      it("converts to an RGB object at +20%", function() {
+        device.color(0x6699cc, .2);
+        var color = { red: 0x7a, green: 0xb8, blue: 0xf5 };
         expect(rgb).to.be.calledWith(color);
       });
 
-      it("converts to an RGB object at 33%", function() {
-        device.color(0xc3FF00, 33);
-        var color = { red: 64, blue: 0, green: 84 };
+      it("converts to an RGB object at -50%", function() {
+        device.color(0x6699cc, -0.5);
+        var color = { red: 0x33, green: 0x4d, blue: 0x66 };
         expect(rgb).to.be.calledWith(color);
       });
 
-      it("converts to an RGB object at 100%", function() {
-        device.color(0xc3FF00, 100);
-        var color = { red: 195, blue: 0, green: 255 };
+      it("converts to an RGB object at normal %", function() {
+        device.color(0x6699cc, 0);
+        var color = { red: 0x66, green: 0x99, blue: 0xcc };
         expect(rgb).to.be.calledWith(color);
       });
     });


### PR DESCRIPTION
Adds additional optional parameter to `color` command, that takes a luminance percentage. This adjusts the passed RGB colors based on the perceived brightness. Example:

```
// sets color to the provided hex value, at 50% luminance
orb.color(0xff0000, 50);

// sets color to the same hex value, at 100% luminance
orb.color(0xff0000, 100);
```
