### PR TITLE
Add setDefaultSettings function

### DIFF
--- a/lib/devices/custom.js
+++ b/lib/devices/custom.js
@@ -315,8 +315,7 @@ module.exports = function custom(device) {
 
   /**
    * The Finish Calibration command ends Sphero's calibration mode, by setting
-   * the new heading as current, turning off the back LED, and re-enabling
-   * stabilization.
+   * the new heading as current, and re-enabling normal defaults
    *
    * @param {Function} callback function to be triggered with response
    * @example
@@ -325,8 +324,22 @@ module.exports = function custom(device) {
    */
   device.finishCalibration = function(callback) {
     device.setHeading(0);
-    device.setBackLed(0);
     device.setRgbLed(device.originalColor);
+    device.setDefaultSettings(callback);
+  };
+
+  /**
+   * The setDefaultSettings command sets Sphero's settings back to sensible
+   * defaults, such as turning off the back LED, and re-enabling
+   * stabilization.
+   *
+   * @param {Function} callback function to be triggered with response
+   * @example
+   * orb.setDefaultSettings();
+   * @return {void}
+   */
+  device.setDefaultSettings = function(callback) {
+    device.setBackLed(0);
     device.setStabilization(1, callback);
   };
 


### PR DESCRIPTION
Add `setDefaultSettings()` function to set Sphero to sensible initial default settings. Used in the `finishCalibration()` function, as well as available to be used in user programs.