### PR TITLE
Simplify calibration code to handle devices with undefined initial state

### DIFF
--- a/lib/devices/custom.js
+++ b/lib/devices/custom.js
@@ -306,11 +306,10 @@ module.exports = function custom(device) {
       if (!err) {
         device.originalColor = data.color;
       }
-
-      device.setRgbLed(0);
-      device.setBackLed(127);
-      device.setStabilization(0, callback);
     });
+    device.setRgbLed(0);
+    device.setBackLed(127);
+    device.setStabilization(0, callback);
   };
 
   /**
@@ -324,8 +323,8 @@ module.exports = function custom(device) {
    */
   device.finishCalibration = function(callback) {
     device.setHeading(0);
-    device.setRgbLed(device.originalColor);
     device.setDefaultSettings(callback);
+    device.setRgbLed(device.originalColor);
   };
 
   /**


### PR DESCRIPTION
Simplify calibration code to handle devices with undefined initial state, in particular stop trying so hard to restore the original color when there isn't one set.