### PR TITLE
Adds promises/callback "dual" interface

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -55,8 +55,29 @@ orb.connect(function() {
 
     setTimeout(function() {
       orb.color("green");
-    }, 1000);
+    }, 100);
   });
+});
+```
+
+You can also use a Promises/A+ interface for your code, instead of the callback-based API:
+
+```javascript
+orb.connect().then(function() {
+  return orb.roll(155, 0);
+}).then(function() {
+  return orb.color("green");
+}).then(orb.detectCollisions);
+
+orb.on("collision", function(data) {
+  console.log("collision detected");
+  console.log("  data:", data);
+
+  orb.color("red")
+    .delay(100)
+    .then(function() {
+      return orb.color("green");
+    });
 });
 ```
 

--- a/examples/promise-bluetooth-info.js
+++ b/examples/promise-bluetooth-info.js
@@ -4,7 +4,7 @@ var sphero = require("../");
 var orb = sphero(process.env.PORT);
 
 orb.connect().then(function() {
-  return orb.color({ red: 255, green: 0, blue: 255 });
+  return orb.color("FF00FF");
 }).then(function() {
   return orb.getBluetoothInfo();
 }).then(function(data) {
@@ -13,4 +13,6 @@ orb.connect().then(function() {
   console.log("  btAddress:", data.btAddress);
   console.log("  separator:", data.separator);
   console.log("  colors:", data.colors);
+}).catch(function(err) {
+  console.error("err:", err);
 });

--- a/examples/promise-bluetooth-info.js
+++ b/examples/promise-bluetooth-info.js
@@ -1,0 +1,16 @@
+"use strict";
+
+var sphero = require("../");
+var orb = sphero(process.env.PORT);
+
+orb.connect().then(function() {
+  return orb.color({ red: 255, green: 0, blue: 255 });
+}).then(function() {
+  return orb.getBluetoothInfo();
+}).then(function(data) {
+  console.log("bluetoothInfo:");
+  console.log("  name:", data.name);
+  console.log("  btAddress:", data.btAddress);
+  console.log("  separator:", data.separator);
+  console.log("  colors:", data.colors);
+});

--- a/examples/promise-collision-detection.js
+++ b/examples/promise-collision-detection.js
@@ -1,0 +1,19 @@
+"use strict";
+
+var sphero = require("../");
+var orb = sphero(process.env.PORT);
+
+orb.connect().then(orb.detectCollisions).then(function() {
+  return orb.color("green");
+}).then(function() {
+  return orb.roll(155, 0);
+});
+
+orb.on("collision", function(data) {
+  console.log("collision detected");
+  console.log("  data:", data);
+
+  orb.color("red").delay(100).then(function() {
+    return orb.color("green");
+  });
+});

--- a/examples/promise-color.js
+++ b/examples/promise-color.js
@@ -1,0 +1,20 @@
+"use strict";
+
+var sphero = require("../");
+var orb = sphero(process.env.PORT);
+
+orb.connect().then(function() {
+  return orb.color({ red: 255, green: 0, blue: 255 });
+}).delay(1000).then(function() {
+  console.log("color 1");
+  // sets color to the provided hex value
+  return orb.color(0xff0000);
+}).delay(1000).then(function() {
+  console.log("color 2");
+  // hex numbers can also be passed in strings
+  return orb.color("00ff00");
+}).delay(1000).then(function() {
+  console.log("color 3");
+  // sets color to the provided color name
+  return orb.color("magenta");
+});

--- a/examples/promise-roll.js
+++ b/examples/promise-roll.js
@@ -1,0 +1,12 @@
+"use strict";
+
+var sphero = require("../");
+var orb = sphero(process.env.PORT);
+
+orb.connect().then(function() {
+  // roll orb in a random direction, changing direction every second
+  setInterval(function() {
+    var direction = Math.floor(Math.random() * 360);
+    orb.roll(150, direction);
+  }, 1000);
+});

--- a/lib/devices/core.js
+++ b/lib/devices/core.js
@@ -15,7 +15,7 @@ module.exports = function core(device) {
    * orb.ping(function(err, data) {
    *   console.log(err || "data: " + data);
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.ping = function(callback) {
     return command(commands.ping, null, callback);
@@ -44,7 +44,7 @@ module.exports = function core(device) {
    *     console.log("  apiMin:", data.apiMin);
    *   }
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.version = function(callback) {
     return command(commands.version, null, callback);
@@ -59,7 +59,7 @@ module.exports = function core(device) {
    * orb.controlUartTx(function(err, data) {
    *   console.log(err || "data: " + data);
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.controlUartTx = function(callback) {
     return command(commands.controlUARTTx, null, callback);
@@ -80,7 +80,7 @@ module.exports = function core(device) {
    * orb.setDeviceName("rollingOrb", function(err, data) {
    *   console.log(err || "data: " + data);
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.setDeviceName = function(name, callback) {
     var data = [];
@@ -112,7 +112,7 @@ module.exports = function core(device) {
    *     console.log("  colors:", data.colors);
    *   }
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.getBluetoothInfo = function(callback) {
     return command(commands.getBtInfo, null, callback);
@@ -130,7 +130,7 @@ module.exports = function core(device) {
    * orb.setAutoReconnect(1, 20, function(err, data) {
    *   console.log(err || "data: " + data);
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.setAutoReconnect = function(flag, time, callback) {
     return command(commands.setAutoReconnect, [flag, time], callback);
@@ -151,7 +151,7 @@ module.exports = function core(device) {
    *     console.log("  time:", data.time);
    *   }
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.getAutoReconnect = function(callback) {
     return command(commands.getAutoReconnect, null, callback);
@@ -189,7 +189,7 @@ module.exports = function core(device) {
    *     console.log("  secondsSinceCharge:", data.secondsSinceCharge);
    *   }
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.getPowerState = function(callback) {
     return command(commands.getPwrState, null, callback);
@@ -208,7 +208,7 @@ module.exports = function core(device) {
    * orb.setPowerNotification(1, function(err, data) {
    *   console.log(err || "data: " + data);
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.setPowerNotification = function(flag, callback) {
     return command(commands.setPwrNotify, [flag], callback);
@@ -229,7 +229,7 @@ module.exports = function core(device) {
    * orb.sleep(10, 0, 0, function(err, data) {
    *   console.log(err || "data: " + data);
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.sleep = function(wakeup, macro, orbBasic, callback) {
     wakeup = utils.intToHexArray(wakeup, 2);
@@ -258,7 +258,7 @@ module.exports = function core(device) {
    *     console.log("  vCrit:", data.vCrit);
    *   }
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.getVoltageTripPoints = function(callback) {
     return command(commands.getPowerTrips, null, callback);
@@ -286,7 +286,7 @@ module.exports = function core(device) {
    * orb.setVoltageTripPoints(675, 650, function(err, data) {
    *   console.log(err || "data: " + data);
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.setVoltageTripPoints = function(vLow, vCrit, callback) {
     vLow = utils.intToHexArray(vLow, 2);
@@ -310,7 +310,7 @@ module.exports = function core(device) {
    * orb.setInactivityTimeout(120, function(err, data) {
    *   console.log(err || "data: " + data);
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.setInactivityTimeout = function(time, callback) {
     var data = utils.intToHexArray(time, 2);
@@ -329,7 +329,7 @@ module.exports = function core(device) {
    * orb.jumpToBootLoader(function(err, data) {
    *   console.log(err || "data: " + data);
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.jumpToBootloader = function(callback) {
     return command(commands.goToBl, null, callback);
@@ -349,7 +349,7 @@ module.exports = function core(device) {
    * orb.runL1Diags(function(err, data) {
    *   console.log(err || "data: " + data);
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.runL1Diags = function(callback) {
     return command(commands.runL1Diags, null, callback);
@@ -390,7 +390,7 @@ module.exports = function core(device) {
    *     console.log("  gyroAdjustCount:", data.gyroAdjustCount);
    *   }
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.runL2Diags = function(callback) {
     return command(commands.runL2Diags, null, callback);
@@ -408,7 +408,7 @@ module.exports = function core(device) {
    * orb.clearCounters(function(err, data) {
    *   console.log(err || "data: " + data);
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.clearCounters = function(callback) {
     return command(commands.clearCounters, null, callback);
@@ -429,7 +429,7 @@ module.exports = function core(device) {
    * orb.assignTime(0x00ffff00, function(err, data) {
    *   console.log(err || "data: " + data);
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.assignTime = function(time, callback) {
     return device._coreTimeCmd(commands.assignTime, time, callback);
@@ -454,7 +454,7 @@ module.exports = function core(device) {
    *     console.log("  t3:", data.t3);
    *   }
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.pollPacketTimes = function(time, callback) {
     return device._coreTimeCmd(commands.pollTimes, time, callback);

--- a/lib/devices/core.js
+++ b/lib/devices/core.js
@@ -18,7 +18,7 @@ module.exports = function core(device) {
    * @return {void}
    */
   device.ping = function(callback) {
-    command(commands.ping, null, callback);
+    return command(commands.ping, null, callback);
   };
 
   /**
@@ -47,7 +47,7 @@ module.exports = function core(device) {
    * @return {void}
    */
   device.version = function(callback) {
-    command(commands.version, null, callback);
+    return command(commands.version, null, callback);
   };
 
   /**
@@ -62,7 +62,7 @@ module.exports = function core(device) {
    * @return {void}
    */
   device.controlUartTx = function(callback) {
-    command(commands.controlUARTTx, null, callback);
+    return command(commands.controlUARTTx, null, callback);
   };
 
   /**
@@ -89,7 +89,7 @@ module.exports = function core(device) {
       data[i] = name.charCodeAt(i);
     }
 
-    command(commands.setDeviceName, data, callback);
+    return command(commands.setDeviceName, data, callback);
   };
 
   /**
@@ -115,7 +115,7 @@ module.exports = function core(device) {
    * @return {void}
    */
   device.getBluetoothInfo = function(callback) {
-    command(commands.getBtInfo, null, callback);
+    return command(commands.getBtInfo, null, callback);
   };
 
   /**
@@ -133,7 +133,7 @@ module.exports = function core(device) {
    * @return {void}
    */
   device.setAutoReconnect = function(flag, time, callback) {
-    command(commands.setAutoReconnect, [flag, time], callback);
+    return command(commands.setAutoReconnect, [flag, time], callback);
   };
 
   /**
@@ -154,7 +154,7 @@ module.exports = function core(device) {
    * @return {void}
    */
   device.getAutoReconnect = function(callback) {
-    command(commands.getAutoReconnect, null, callback);
+    return command(commands.getAutoReconnect, null, callback);
   };
 
   /**
@@ -192,7 +192,7 @@ module.exports = function core(device) {
    * @return {void}
    */
   device.getPowerState = function(callback) {
-    command(commands.getPwrState, null, callback);
+    return command(commands.getPwrState, null, callback);
   };
 
   /**
@@ -211,7 +211,7 @@ module.exports = function core(device) {
    * @return {void}
    */
   device.setPowerNotification = function(flag, callback) {
-    command(commands.setPwrNotify, [flag], callback);
+    return command(commands.setPwrNotify, [flag], callback);
   };
 
   /**
@@ -237,7 +237,7 @@ module.exports = function core(device) {
 
     var data = [].concat(wakeup, macro, orbBasic);
 
-    command(commands.sleep, data, callback);
+    return command(commands.sleep, data, callback);
   };
 
   /**
@@ -261,7 +261,7 @@ module.exports = function core(device) {
    * @return {void}
    */
   device.getVoltageTripPoints = function(callback) {
-    command(commands.getPowerTrips, null, callback);
+    return command(commands.getPowerTrips, null, callback);
   };
 
   /**
@@ -294,7 +294,7 @@ module.exports = function core(device) {
 
     var data = [].concat(vLow, vCrit);
 
-    command(commands.setPowerTrips, data, callback);
+    return command(commands.setPowerTrips, data, callback);
   };
 
   /**
@@ -314,7 +314,7 @@ module.exports = function core(device) {
    */
   device.setInactivityTimeout = function(time, callback) {
     var data = utils.intToHexArray(time, 2);
-    command(commands.setInactiveTimer, data, callback);
+    return command(commands.setInactiveTimer, data, callback);
   };
 
   /**
@@ -332,7 +332,7 @@ module.exports = function core(device) {
    * @return {void}
    */
   device.jumpToBootloader = function(callback) {
-    command(commands.goToBl, null, callback);
+    return command(commands.goToBl, null, callback);
   };
 
   /**
@@ -352,7 +352,7 @@ module.exports = function core(device) {
    * @return {void}
    */
   device.runL1Diags = function(callback) {
-    command(commands.runL1Diags, null, callback);
+    return command(commands.runL1Diags, null, callback);
   };
 
   /**
@@ -393,7 +393,7 @@ module.exports = function core(device) {
    * @return {void}
    */
   device.runL2Diags = function(callback) {
-    command(commands.runL2Diags, null, callback);
+    return command(commands.runL2Diags, null, callback);
   };
 
   /**
@@ -411,12 +411,12 @@ module.exports = function core(device) {
    * @return {void}
    */
   device.clearCounters = function(callback) {
-    command(commands.clearCounters, null, callback);
+    return command(commands.clearCounters, null, callback);
   };
 
   device._coreTimeCmd = function(cmd, time, callback) {
     var data = utils.intToHexArray(time, 4);
-    command(cmd, data, callback);
+    return command(cmd, data, callback);
   };
 
   /**
@@ -432,7 +432,7 @@ module.exports = function core(device) {
    * @return {void}
    */
   device.assignTime = function(time, callback) {
-    device._coreTimeCmd(commands.assignTime, time, callback);
+    return device._coreTimeCmd(commands.assignTime, time, callback);
   };
 
   /**
@@ -457,6 +457,6 @@ module.exports = function core(device) {
    * @return {void}
    */
   device.pollPacketTimes = function(time, callback) {
-    device._coreTimeCmd(commands.pollTimes, time, callback);
+    return device._coreTimeCmd(commands.pollTimes, time, callback);
   };
 };

--- a/lib/devices/custom.js
+++ b/lib/devices/custom.js
@@ -94,7 +94,7 @@ module.exports = function custom(device) {
       device.emit(args.event, params);
     });
 
-    device.setDataStreaming(opts);
+    return device.setDataStreaming(opts);
   };
 
   /**
@@ -165,7 +165,7 @@ module.exports = function custom(device) {
       color = adjustLuminance(color, luminance);
     }
 
-    device.setRgbLed(color, cb);
+    return device.setRgbLed(color, cb);
   };
 
   /**
@@ -179,7 +179,7 @@ module.exports = function custom(device) {
    * @return {void}
    */
   device.randomColor = function(callback) {
-    device.setRgbLed(utils.randomColor(), callback);
+    return device.setRgbLed(utils.randomColor(), callback);
   };
 
   /**
@@ -201,7 +201,7 @@ module.exports = function custom(device) {
    * @return {void}
    */
   device.getColor = function(callback) {
-    device.getRgbLed(callback);
+    return device.getRgbLed(callback);
   };
 
   /**
@@ -247,7 +247,7 @@ module.exports = function custom(device) {
         dead: 0x01
       };
     }
-    device.configureCollisions(presets, callback);
+    return device.configureCollisions(presets, callback);
   };
 
   /**
@@ -282,7 +282,7 @@ module.exports = function custom(device) {
       }
     });
 
-    device.streamAccelOne(callback);
+    return device.streamAccelOne(callback);
   };
 
   /**
@@ -309,7 +309,7 @@ module.exports = function custom(device) {
     });
     device.setRgbLed(0);
     device.setBackLed(127);
-    device.setStabilization(0, callback);
+    return device.setStabilization(0, callback);
   };
 
   /**
@@ -323,8 +323,8 @@ module.exports = function custom(device) {
    */
   device.finishCalibration = function(callback) {
     device.setHeading(0);
-    device.setDefaultSettings(callback);
     device.setRgbLed(device.originalColor);
+    return device.setDefaultSettings(callback);
   };
 
   /**
@@ -339,7 +339,7 @@ module.exports = function custom(device) {
    */
   device.setDefaultSettings = function(callback) {
     device.setBackLed(0);
-    device.setStabilization(1, callback);
+    return device.setStabilization(1, callback);
   };
 
   /**
@@ -361,7 +361,7 @@ module.exports = function custom(device) {
    * @return {void}
    */
   device.streamOdometer = function(sps, remove) {
-    device.streamData({
+    return device.streamData({
       event: "odometer",
       mask2: 0x0C000000,
       fields: ["xOdometer", "yOdometer"],
@@ -389,7 +389,7 @@ module.exports = function custom(device) {
    * @return {void}
    */
   device.streamVelocity = function(sps, remove) {
-    device.streamData({
+    return device.streamData({
       event: "velocity",
       mask2: 0x01800000,
       fields: ["xVelocity", "yVelocity"],
@@ -416,7 +416,7 @@ module.exports = function custom(device) {
    * @return {void}
    */
   device.streamAccelOne = function(sps, remove) {
-    device.streamData({
+    return device.streamData({
       event: "accelOne",
       mask2: 0x02000000,
       fields: ["accelOne"],
@@ -445,7 +445,7 @@ module.exports = function custom(device) {
    * @return {void}
    */
   device.streamImuAngles = function(sps, remove) {
-    device.streamData({
+    return device.streamData({
       event: "imuAngles",
       mask1: 0x00070000,
       fields: ["pitchAngle", "rollAngle", "yawAngle"],
@@ -474,7 +474,7 @@ module.exports = function custom(device) {
    * @return {void}
    */
   device.streamAccelerometer = function(sps, remove) {
-    device.streamData({
+    return device.streamData({
       event: "accelerometer",
       mask1: 0x0000E000,
       fields: ["xAccel", "yAccel", "zAccel"],
@@ -503,7 +503,7 @@ module.exports = function custom(device) {
    * @return {void}
    */
   device.streamGyroscope = function(sps, remove) {
-    device.streamData({
+    return device.streamData({
       event: "gyroscope",
       mask1: 0x00001C00,
       fields: ["xGyro", "yGyro", "zGyro"],
@@ -531,7 +531,7 @@ module.exports = function custom(device) {
    * @return {void}
    */
   device.streamMotorsBackEmf = function(sps, remove) {
-    device.streamData({
+    return device.streamData({
       event: "motorsBackEmf",
       mask1: 0x00000060,
       fields: ["rMotorBackEmf", "lMotorBackEmf"],
@@ -561,7 +561,7 @@ module.exports = function custom(device) {
 
     var bitmask = (remove) ? 0x00 : 0x01;
 
-    device.setTempOptionFlags(bitmask, callback);
+    return device.setTempOptionFlags(bitmask, callback);
   };
 
 
@@ -577,6 +577,6 @@ module.exports = function custom(device) {
    * @return {void}
    */
   device.stop = function(callback) {
-    this.roll(0, 0, 0, callback);
+    return this.roll(0, 0, 0, callback);
   };
 };

--- a/lib/devices/custom.js
+++ b/lib/devices/custom.js
@@ -72,7 +72,7 @@ module.exports = function custom(device) {
    *
    * @private
    * @param {Object} args event, masks, fields, and sps data
-   * @return {void}
+   * @return {object} promise for command
    */
   device.streamData = function(args) {
     // options for streaming data
@@ -116,7 +116,7 @@ module.exports = function custom(device) {
    * orb.color({ red: 0, green: 0, blue: 255 }, function(err, data) {
    *   console.log(err || "Color Changed!");
    * });
-   * @return {void}
+   * @return {object} promise for command
    */
   device.color = function(color, luminance, callback) {
     var cb = callback;
@@ -176,7 +176,7 @@ module.exports = function custom(device) {
    * orb.randomColor(function(err, data) {
    *   console.log(err || "Random Color!");
    * });
-   * @return {void}
+   * @return {object} promise for command
    */
   device.randomColor = function(callback) {
     return device.setRgbLed(utils.randomColor(), callback);
@@ -198,7 +198,7 @@ module.exports = function custom(device) {
    *     console.log("  blue:", data.blue);
    *   }
    * });
-   * @return {void}
+   * @return {object} promise for command
    */
   device.getColor = function(callback) {
     return device.getRgbLed(callback);
@@ -225,7 +225,7 @@ module.exports = function custom(device) {
    *   console.log("  speed:", data.timeStamp);
    *   console.log("  timeStamp:", data.timeStamp);
    * });
-   * @return {void}
+   * @return {object} promise for command
    */
   device.detectCollisions = function(opts, callback) {
     var presets = {
@@ -267,7 +267,7 @@ module.exports = function custom(device) {
    *   console.log("landing:");
    *   console.log("  value:", data.value);
    * });
-   * @return {void}
+   * @return {object} promise for command
    */
   device.detectFreefall = function(callback) {
     var falling = false;
@@ -298,7 +298,7 @@ module.exports = function custom(device) {
    * @param {Function} callback (err, data) to be triggered with response
    * @example
    * orb.startCalibration();
-   * @return {void}
+   * @return {object} promise for command
    */
   device.startCalibration = function(callback) {
     device.originalColor = 0;
@@ -319,7 +319,7 @@ module.exports = function custom(device) {
    * @param {Function} callback function to be triggered with response
    * @example
    * orb.finishCalibration();
-   * @return {void}
+   * @return {object} promise for command
    */
   device.finishCalibration = function(callback) {
     device.setHeading(0);
@@ -335,7 +335,7 @@ module.exports = function custom(device) {
    * @param {Function} callback function to be triggered with response
    * @example
    * orb.setDefaultSettings();
-   * @return {void}
+   * @return {object} promise for command
    */
   device.setDefaultSettings = function(callback) {
     device.setBackLed(0);
@@ -358,7 +358,7 @@ module.exports = function custom(device) {
    *   console.log("  xOdomoter:", data.xOdomoter);
    *   console.log("  yOdomoter:", data.yOdomoter);
    * });
-   * @return {void}
+   * @return {object} promise for command
    */
   device.streamOdometer = function(sps, remove) {
     return device.streamData({
@@ -386,7 +386,7 @@ module.exports = function custom(device) {
    *   console.log("  xVelocity:", data.xVelocity);
    *   console.log("  yVelocity:", data.yVelocity);
    * });
-   * @return {void}
+   * @return {object} promise for command
    */
   device.streamVelocity = function(sps, remove) {
     return device.streamData({
@@ -413,7 +413,7 @@ module.exports = function custom(device) {
    *   console.log("data:");
    *   console.log("  accelOne:", data.accelOne);
    * });
-   * @return {void}
+   * @return {object} promise for command
    */
   device.streamAccelOne = function(sps, remove) {
     return device.streamData({
@@ -442,7 +442,7 @@ module.exports = function custom(device) {
    *   console.log("  rollAngle:", data.rollAngle);
    *   console.log("  yawAngle:", data.yawAngle);
    * });
-   * @return {void}
+   * @return {object} promise for command
    */
   device.streamImuAngles = function(sps, remove) {
     return device.streamData({
@@ -471,7 +471,7 @@ module.exports = function custom(device) {
    *   console.log("  yAccel:", data.yAccel);
    *   console.log("  zAccel:", data.zAccel);
    * });
-   * @return {void}
+   * @return {object} promise for command
    */
   device.streamAccelerometer = function(sps, remove) {
     return device.streamData({
@@ -500,7 +500,7 @@ module.exports = function custom(device) {
    *   console.log("  yGyro:", data.yGyro);
    *   console.log("  zGyro:", data.zGyro);
    * });
-   * @return {void}
+   * @return {object} promise for command
    */
   device.streamGyroscope = function(sps, remove) {
     return device.streamData({
@@ -528,7 +528,7 @@ module.exports = function custom(device) {
    *   console.log("  rMotorBackEmf:", data.rMotorBackEmf);
    *   console.log("  lMotorBackEmf:", data.lMotorBackEmf);
    * });
-   * @return {void}
+   * @return {object} promise for command
    */
   device.streamMotorsBackEmf = function(sps, remove) {
     return device.streamData({
@@ -551,7 +551,7 @@ module.exports = function custom(device) {
    * orb.stopOnDisconnect(function(err, data) {
    *   console.log(err || "data" + data);
    * });
-   * @return {void}
+   * @return {object} promise for command
    */
   device.stopOnDisconnect = function(remove, callback) {
     if (typeof remove === "function") {
@@ -574,7 +574,7 @@ module.exports = function custom(device) {
    * sphero.stop(function(err, data) {
    *   console.log(err || "data" + data);
    * });
-   * @return {void}
+   * @return {object} promise for command
    */
   device.stop = function(callback) {
     return this.roll(0, 0, 0, callback);

--- a/lib/devices/sphero.js
+++ b/lib/devices/sphero.js
@@ -23,7 +23,7 @@ module.exports = function sphero(device) {
    */
   device.setHeading = function(heading, callback) {
     heading = utils.intToHexArray(heading, 2);
-    command(commands.setHeading, heading, callback);
+    return command(commands.setHeading, heading, callback);
   };
 
   /**
@@ -40,7 +40,7 @@ module.exports = function sphero(device) {
    */
   device.setStabilization = function(flag, callback) {
     flag &= 0x01;
-    command(commands.setStabilization, [flag], callback);
+    return command(commands.setStabilization, [flag], callback);
   };
 
   /**
@@ -63,7 +63,7 @@ module.exports = function sphero(device) {
    */
   device.setRotationRate = function(rotation, callback) {
     rotation &= 0xFF;
-    command(commands.setRotationRate, [rotation], callback);
+    return command(commands.setRotationRate, [rotation], callback);
   };
 
   /**
@@ -83,7 +83,7 @@ module.exports = function sphero(device) {
    * @return {void}
    */
   device.getChassisId = function(callback) {
-    command(commands.getChassisId, null, callback);
+    return command(commands.getChassisId, null, callback);
   };
 
   /**
@@ -102,7 +102,7 @@ module.exports = function sphero(device) {
    */
   device.setChassisId = function(chassisId, callback) {
     chassisId = utils.intToHexArray(chassisId, 2);
-    command(commands.getChassisId, chassisId, callback);
+    return command(commands.getChassisId, chassisId, callback);
   };
 
   /**
@@ -147,7 +147,7 @@ module.exports = function sphero(device) {
       opts.timeout,
       opts.trueTime
     ];
-    command(commands.selfLevel, data, callback);
+    return command(commands.selfLevel, data, callback);
   };
 
   /**
@@ -198,7 +198,7 @@ module.exports = function sphero(device) {
 
     var data = [].concat(n, m, mask1, pcnt, mask2);
 
-    command(commands.setDataStreaming, data, callback);
+    return command(commands.setDataStreaming, data, callback);
   };
 
   /**
@@ -245,7 +245,7 @@ module.exports = function sphero(device) {
       opts.ys,
       opts.dead
     ];
-    command(commands.setCollisionDetection, data, cb);
+    return command(commands.setCollisionDetection, data, cb);
   };
 
   /**
@@ -286,7 +286,7 @@ module.exports = function sphero(device) {
 
     var data = [].concat(flags, x, y, yawTare);
 
-    command(commands.locator, data, callback);
+    return command(commands.locator, data, callback);
   };
 
   /**
@@ -313,7 +313,7 @@ module.exports = function sphero(device) {
    */
   device.setAccelRange = function(idx, callback) {
     idx &= idx;
-    command(commands.setAccelerometer, [idx], callback);
+    return command(commands.setAccelerometer, [idx], callback);
   };
 
   /**
@@ -340,7 +340,7 @@ module.exports = function sphero(device) {
    * @return {void}
    */
   device.readLocator = function(callback) {
-    command(commands.readLocator, null, callback);
+    return command(commands.readLocator, null, callback);
   };
 
   /**
@@ -366,7 +366,7 @@ module.exports = function sphero(device) {
       data[i] &= 0xFF;
     }
 
-    command(commands.setRgbLed, data, callback);
+    return command(commands.setRgbLed, data, callback);
   };
 
   /**
@@ -384,7 +384,7 @@ module.exports = function sphero(device) {
    * @return {void}
    */
   device.setBackLed = function(brightness, callback) {
-    command(commands.setBackLed, [brightness], callback);
+    return command(commands.setBackLed, [brightness], callback);
   };
 
   /**
@@ -409,7 +409,7 @@ module.exports = function sphero(device) {
    * @return {void}
    */
   device.getRgbLed = function(callback) {
-    command(commands.getRgbLed, null, callback);
+    return command(commands.getRgbLed, null, callback);
   };
 
   /**
@@ -442,7 +442,7 @@ module.exports = function sphero(device) {
 
     var data = [].concat(speed, heading, state);
 
-    command(commands.roll, data, callback);
+    return command(commands.roll, data, callback);
   };
 
   /**
@@ -460,7 +460,7 @@ module.exports = function sphero(device) {
    */
   device.boost = function(boost, callback) {
     boost &= 0x01;
-    command(commands.boost, [boost], callback);
+    return command(commands.boost, [boost], callback);
   };
 
   /**
@@ -503,7 +503,7 @@ module.exports = function sphero(device) {
 
     var data = [lmode, lpower, rmode, rpower];
 
-    command(commands.setRawMotors, data, callback);
+    return command(commands.setRawMotors, data, callback);
   };
 
   /**
@@ -523,7 +523,7 @@ module.exports = function sphero(device) {
    */
   device.setMotionTimeout = function(time, callback) {
     time = utils.intToHexArray(time, 2);
-    command(commands.setMotionTimeout, time, callback);
+    return command(commands.setMotionTimeout, time, callback);
   };
 
   /**
@@ -544,7 +544,7 @@ module.exports = function sphero(device) {
    */
   device.setPermOptionFlags = function(flags, callback) {
     flags = utils.intToHexArray(flags, 4);
-    command(commands.setOptionsFlag, flags, callback);
+    return command(commands.setOptionsFlag, flags, callback);
   };
 
   /**
@@ -590,7 +590,7 @@ module.exports = function sphero(device) {
    * @return {void}
    */
   device.getPermOptionFlags = function(callback) {
-    command(commands.getOptionsFlag, null, callback);
+    return command(commands.getOptionsFlag, null, callback);
   };
 
   /**
@@ -610,7 +610,7 @@ module.exports = function sphero(device) {
    */
   device.setTempOptionFlags = function(flags, callback) {
     flags = utils.intToHexArray(flags, 4);
-    command(commands.setTempOptionFlags, flags, callback);
+    return command(commands.setTempOptionFlags, flags, callback);
   };
 
   /**
@@ -633,7 +633,7 @@ module.exports = function sphero(device) {
    * @return {void}
    */
   device.getTempOptionFlags = function(callback) {
-    command(commands.getTempOptionFlags, null, callback);
+    return command(commands.getTempOptionFlags, null, callback);
   };
 
   /**
@@ -659,13 +659,13 @@ module.exports = function sphero(device) {
    */
   device.getConfigBlock = function(id, callback) {
     id &= 0xFF;
-    command(commands.getConfigBlock, [id], callback);
+    return command(commands.getConfigBlock, [id], callback);
   };
 
   device._setSsbBlock = function(cmd, pwd, block, callback) {
     pwd = utils.intToHexArray(pwd, 4);
     var data = [].concat(pwd, block);
-    command(cmd, data, callback);
+    return command(cmd, data, callback);
   };
 
   /**
@@ -684,7 +684,7 @@ module.exports = function sphero(device) {
    * @return {void}
    */
   device.setSsbModBlock = function(pwd, block, callback) {
-    device._setSsbBlock(commands.setSsbParams, pwd, block, callback);
+    return device._setSsbBlock(commands.setSsbParams, pwd, block, callback);
   };
 
   /**
@@ -705,7 +705,7 @@ module.exports = function sphero(device) {
    */
   device.setDeviceMode = function(mode, callback) {
     mode &= 0x01;
-    command(commands.setDeviceMode, [mode], callback);
+    return command(commands.setDeviceMode, [mode], callback);
   };
 
   /**
@@ -727,7 +727,7 @@ module.exports = function sphero(device) {
    * @return {void}
    */
   device.setConfigBlock = function(block, callback) {
-    command(commands.setConfigBlock, block, callback);
+    return command(commands.setConfigBlock, block, callback);
   };
 
   /**
@@ -751,7 +751,7 @@ module.exports = function sphero(device) {
    * @return {void}
    */
   device.getDeviceMode = function(callback) {
-    command(commands.getDeviceMode, null, callback);
+    return command(commands.getDeviceMode, null, callback);
   };
 
   /**
@@ -769,7 +769,7 @@ module.exports = function sphero(device) {
    * @return {void}
    */
   device.getSsb = function(callback) {
-    command(commands.getSsb, null, callback);
+    return command(commands.getSsb, null, callback);
   };
 
   /**
@@ -791,7 +791,7 @@ module.exports = function sphero(device) {
    * @return {void}
    */
   device.setSsb = function(pwd, block, callback) {
-    device._setSsbBlock(commands.setSsb, pwd, block, callback);
+    return device._setSsbBlock(commands.setSsb, pwd, block, callback);
   };
 
   /**
@@ -817,7 +817,7 @@ module.exports = function sphero(device) {
    */
   device.refillBank = function(type, callback) {
     type &= 0xFF;
-    command(commands.ssbRefill, [type], callback);
+    return command(commands.ssbRefill, [type], callback);
   };
 
   /**
@@ -847,7 +847,7 @@ module.exports = function sphero(device) {
   device.buyConsumable = function(id, qty, callback) {
     id &= 0xFF;
     qty &= 0xFF;
-    command(commands.ssbBuy, [id, qty], callback);
+    return command(commands.ssbBuy, [id, qty], callback);
   };
 
   /**
@@ -871,7 +871,7 @@ module.exports = function sphero(device) {
    */
   device.useConsumable = function(id, callback) {
     id &= 0xFF;
-    command(commands.ssbUseConsumeable, [id], callback);
+    return command(commands.ssbUseConsumeable, [id], callback);
   };
 
   /**
@@ -902,14 +902,14 @@ module.exports = function sphero(device) {
 
     var data = [].concat(pw, qty, flags);
 
-    command(commands.ssbGrantCores, data, callback);
+    return command(commands.ssbGrantCores, data, callback);
   };
 
   device._xpOrLevelUp = function(cmd, pw, gen, cb) {
     pw = utils.intToHexArray(pw, 4);
     gen &= 0xFF;
 
-    command(cmd, [].concat(pw, gen), cb);
+    return command(cmd, [].concat(pw, gen), cb);
   };
 
   /**
@@ -929,7 +929,7 @@ module.exports = function sphero(device) {
    * @return {void}
    */
   device.addXp = function(pw, qty, callback) {
-    device._xpOrLevelUp(commands.ssbAddXp, pw, qty, callback);
+    return device._xpOrLevelUp(commands.ssbAddXp, pw, qty, callback);
   };
 
   /**
@@ -964,7 +964,7 @@ module.exports = function sphero(device) {
    * @return {void}
    */
   device.levelUpAttr = function(pw, id, callback) {
-    device._xpOrLevelUp(commands.ssbLevelUpAttr, pw, id, callback);
+    return device._xpOrLevelUp(commands.ssbLevelUpAttr, pw, id, callback);
   };
 
   /**
@@ -983,7 +983,7 @@ module.exports = function sphero(device) {
    * @return {void}
    */
   device.getPasswordSeed = function(callback) {
-    command(commands.getPwSeed, null, callback);
+    return command(commands.getPwSeed, null, callback);
   };
 
   /**
@@ -1006,7 +1006,7 @@ module.exports = function sphero(device) {
    */
   device.enableSsbAsyncMsg = function(flag, callback) {
     flag &= 0x01;
-    command(commands.ssbEnableAsync, [flag], callback);
+    return command(commands.ssbEnableAsync, [flag], callback);
   };
 
   /**
@@ -1039,7 +1039,7 @@ module.exports = function sphero(device) {
    */
   device.runMacro = function(id, callback) {
     id &= 0xFF;
-    command(commands.runMacro, [id], callback);
+    return command(commands.runMacro, [id], callback);
   };
 
   /**
@@ -1059,7 +1059,7 @@ module.exports = function sphero(device) {
    * @return {void}
    */
   device.saveTempMacro = function(macro, callback) {
-    command(commands.saveTempMacro, macro, callback);
+    return command(commands.saveTempMacro, macro, callback);
   };
 
   /** Save macro
@@ -1083,7 +1083,7 @@ module.exports = function sphero(device) {
    * @return {void}
    */
   device.saveMacro = function(macro, callback) {
-    command(commands.saveMacro, macro, callback);
+    return command(commands.saveMacro, macro, callback);
   };
 
   /**
@@ -1100,7 +1100,7 @@ module.exports = function sphero(device) {
    * @return {void}
    */
   device.reInitMacroExec = function(callback) {
-    command(commands.initMacroExecutive, null, callback);
+    return command(commands.initMacroExecutive, null, callback);
   };
 
   /**
@@ -1126,7 +1126,7 @@ module.exports = function sphero(device) {
    * @return {void}
    */
   device.abortMacro = function(callback) {
-    command(commands.abortMacro, null, callback);
+    return command(commands.abortMacro, null, callback);
   };
 
   /**
@@ -1150,7 +1150,7 @@ module.exports = function sphero(device) {
    * @return {void}
    */
   device.getMacroStatus = function(callback) {
-    command(commands.macroStatus, null, callback);
+    return command(commands.macroStatus, null, callback);
   };
 
   /**
@@ -1181,7 +1181,7 @@ module.exports = function sphero(device) {
    * @return {void}
    */
   device.setMacroParam = function(index, val1, val2, callback) {
-    command(
+    return command(
       commands.setMacroParam,
       utils.argsToHexArray(index, val1, val2),
       callback
@@ -1215,7 +1215,7 @@ module.exports = function sphero(device) {
    * @return {void}
    */
   device.appendMacroChunk = function(chunk, callback) {
-    command(commands.appendTempMacroChunk, chunk, callback);
+    return command(commands.appendTempMacroChunk, chunk, callback);
   };
 
   /**
@@ -1235,7 +1235,7 @@ module.exports = function sphero(device) {
    */
   device.eraseOrbBasicStorage = function(area, callback) {
     area &= 0xFF;
-    command(commands.eraseOBStorage, [area], callback);
+    return command(commands.eraseOBStorage, [area], callback);
   };
 
   /**
@@ -1264,7 +1264,7 @@ module.exports = function sphero(device) {
   device.appendOrbBasicFragment = function(area, code, callback) {
     area &= 0xFF;
     var data = [].concat(area, code);
-    command(commands.appendOBFragment, data, callback);
+    return command(commands.appendOBFragment, data, callback);
   };
 
   /**
@@ -1284,7 +1284,7 @@ module.exports = function sphero(device) {
    * @return {void}
    */
   device.executeOrbBasicProgram = function(area, slMSB, slLSB, callback) {
-    command(
+    return command(
       commands.execOBProgram,
       utils.argsToHexArray(area, slMSB, slLSB),
       callback
@@ -1303,7 +1303,7 @@ module.exports = function sphero(device) {
    * @return {void}
    */
   device.abortOrbBasicProgram = function(callback) {
-    command(commands.abortOBProgram, null, callback);
+    return command(commands.abortOBProgram, null, callback);
   };
 
   /**
@@ -1325,7 +1325,7 @@ module.exports = function sphero(device) {
    */
   device.submitValueToInput = function(val, callback) {
     val = utils.intToHexArray(val, 4);
-    command(commands.answerInput, val, callback);
+    return command(commands.answerInput, val, callback);
   };
 
   /**
@@ -1342,10 +1342,10 @@ module.exports = function sphero(device) {
    * @return {void}
    */
   device.commitToFlash = function(callback) {
-    command(commands.commitToFlash, null, callback);
+    return command(commands.commitToFlash, null, callback);
   };
 
   device._commitToFlashAlias = function(callback) {
-    command(commands.commitToFlashAlias, null, callback);
+    return command(commands.commitToFlashAlias, null, callback);
   };
 };

--- a/lib/devices/sphero.js
+++ b/lib/devices/sphero.js
@@ -19,7 +19,7 @@ module.exports = function sphero(device) {
    * orb.setHeading(180, function(err, data) {
    *   console.log(err || "data: " + data);
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.setHeading = function(heading, callback) {
     heading = utils.intToHexArray(heading, 2);
@@ -36,7 +36,7 @@ module.exports = function sphero(device) {
    * orb.setStabilization(1, function(err, data) {
    *   console.log(err || "data: " + data);
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.setStabilization = function(flag, callback) {
     flag &= 0x01;
@@ -59,7 +59,7 @@ module.exports = function sphero(device) {
    * orb.setRotationRate(180, function(err, data) {
    *   console.log(err || "data: " + data);
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.setRotationRate = function(rotation, callback) {
     rotation &= 0xFF;
@@ -80,7 +80,7 @@ module.exports = function sphero(device) {
    *     console.log("  chassisId:", data.chassisId);
    *   }
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.getChassisId = function(callback) {
     return command(commands.getChassisId, null, callback);
@@ -98,7 +98,7 @@ module.exports = function sphero(device) {
    * orb.setChassisId(0xFE75, function(err, data) {
    *   console.log(err || "data: " + data);
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.setChassisId = function(chassisId, callback) {
     chassisId = utils.intToHexArray(chassisId, 2);
@@ -138,7 +138,7 @@ module.exports = function sphero(device) {
    * orb.selfLevel(opts, function(err, data) {
    *   console.log(err || "data: " + data);
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.selfLevel = function(opts, callback) {
     var data = [
@@ -182,7 +182,7 @@ module.exports = function sphero(device) {
    * orb.setDataStreaming(opts, function(err, data) {
    *   console.log(err || "data: " + data);
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.setDataStreaming = function(opts, callback) {
     var n = utils.intToHexArray(opts.n, 2),
@@ -234,7 +234,7 @@ module.exports = function sphero(device) {
    * orb.configureCollisions(opts, function(err, data) {
    *   console.log(err || "data: " + data);
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.configureCollisions = function(opts, cb) {
     var data = [
@@ -276,7 +276,7 @@ module.exports = function sphero(device) {
    * orb.configureLocator(opts, function(err, data) {
    *   console.log(err || "data: " + data);
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.configureLocator = function(opts, callback) {
     var flags = opts.flags & 0xFF,
@@ -309,7 +309,7 @@ module.exports = function sphero(device) {
    * orb.setAccelRange(0x02, function(err, data) {
    *   console.log(err || "data: " + data);
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.setAccelRange = function(idx, callback) {
     idx &= idx;
@@ -337,7 +337,7 @@ module.exports = function sphero(device) {
    *     console.log("  sog:", data.sog);
    *   }
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.readLocator = function(callback) {
     return command(commands.readLocator, null, callback);
@@ -357,7 +357,7 @@ module.exports = function sphero(device) {
    * orb.setRgbLed({ red: 0, green: 0, blue: 255 }, function(err, data) {
    *   console.log(err || "data: " + data);
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.setRgbLed = function(opts, callback) {
     var data = [opts.red, opts.green, opts.blue, opts.flag || 0x01];
@@ -381,7 +381,7 @@ module.exports = function sphero(device) {
    * orb.setbackLed(255, function(err, data) {
    *   console.log(err || "data: " + data);
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.setBackLed = function(brightness, callback) {
     return command(commands.setBackLed, [brightness], callback);
@@ -406,7 +406,7 @@ module.exports = function sphero(device) {
    *     console.log("  blue:", data.blue);
    *   }
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.getRgbLed = function(callback) {
     return command(commands.getRgbLed, null, callback);
@@ -428,7 +428,7 @@ module.exports = function sphero(device) {
    * orb.roll(100, 0, function() {
    *   console.log("rolling...");
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.roll = function(speed, heading, state, callback) {
     if (typeof state === "function" || typeof state === "undefined") {
@@ -456,7 +456,7 @@ module.exports = function sphero(device) {
    * orb.boost(1, function(err, data) {
    *   console.log(err || "data: " + data);
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.boost = function(boost, callback) {
     boost &= 0x01;
@@ -493,7 +493,7 @@ module.exports = function sphero(device) {
    * orb.setRawMotors(opts, function(err, data) {
    *   console.log(err || "data: " + data);
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.setRawMotors = function(opts, callback) {
     var lmode = opts.lmode & 0x07,
@@ -519,7 +519,7 @@ module.exports = function sphero(device) {
    * orb.setMotionTimeout(0x0FFF, function(err, data) {
    *   console.log(err || "data: " + data);
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.setMotionTimeout = function(time, callback) {
     time = utils.intToHexArray(time, 2);
@@ -540,7 +540,7 @@ module.exports = function sphero(device) {
    * orb.setPermOptionFlags(0x00000008, function(err, data) {
    *   console.log(err || "data: " + data);
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.setPermOptionFlags = function(flags, callback) {
     flags = utils.intToHexArray(flags, 4);
@@ -587,7 +587,7 @@ module.exports = function sphero(device) {
    *     console.log("  gyroMaxAsyncMsg:", data.gyroMaxAsyncMsg);
    *   }
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.getPermOptionFlags = function(callback) {
     return command(commands.getOptionsFlag, null, callback);
@@ -606,7 +606,7 @@ module.exports = function sphero(device) {
    * orb.setTempOptionFlags(0x01, function(err, data) {
    *   console.log(err || "data: " + data);
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.setTempOptionFlags = function(flags, callback) {
     flags = utils.intToHexArray(flags, 4);
@@ -630,7 +630,7 @@ module.exports = function sphero(device) {
    *     console.log("  stopOnDisconnect:", data.stopOnDisconnect);
    *   }
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.getTempOptionFlags = function(callback) {
     return command(commands.getTempOptionFlags, null, callback);
@@ -655,7 +655,7 @@ module.exports = function sphero(device) {
    * orb.getConfigBlock(function(err, data) {
    *   console.log(err || "data: " + data);
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.getConfigBlock = function(id, callback) {
     id &= 0xFF;
@@ -681,7 +681,7 @@ module.exports = function sphero(device) {
    * orb.setSsbModBlock(0x0000000F, data, function(err, data) {
    *   console.log(err || "data: " + data);
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.setSsbModBlock = function(pwd, block, callback) {
     return device._setSsbBlock(commands.setSsbParams, pwd, block, callback);
@@ -701,7 +701,7 @@ module.exports = function sphero(device) {
    * orb.setDeviceMode(0x00, function(err, data) {
    *   console.log(err || "data: " + data);
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.setDeviceMode = function(mode, callback) {
     mode &= 0x01;
@@ -724,7 +724,7 @@ module.exports = function sphero(device) {
    * orb.setConfigBlock(dataBlock, function(err, data) {
    *   console.log(err || "data: " + data);
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.setConfigBlock = function(block, callback) {
     return command(commands.setConfigBlock, block, callback);
@@ -748,7 +748,7 @@ module.exports = function sphero(device) {
    *     console.log("  mode:", data.mode);
    *   }
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.getDeviceMode = function(callback) {
     return command(commands.getDeviceMode, null, callback);
@@ -766,7 +766,7 @@ module.exports = function sphero(device) {
    * orb.getSsb(function(err, data) {
    *   console.log(err || "data: " + data);
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.getSsb = function(callback) {
     return command(commands.getSsb, null, callback);
@@ -788,7 +788,7 @@ module.exports = function sphero(device) {
    * orb.setSsb(pwd, block, function(err, data) {
    *   console.log(err || "data: " + data);
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.setSsb = function(pwd, block, callback) {
     return device._setSsbBlock(commands.setSsb, pwd, block, callback);
@@ -813,7 +813,7 @@ module.exports = function sphero(device) {
    * orb.refillBank(0x00, function(err, data) {
    *   console.log(err || "data: " + data);
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.refillBank = function(type, callback) {
     type &= 0xFF;
@@ -842,7 +842,7 @@ module.exports = function sphero(device) {
    * orb.buyConsumable(0x00, 5, function(err, data) {
    *   console.log(err || "data: " + data);
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.buyConsumable = function(id, qty, callback) {
     id &= 0xFF;
@@ -867,7 +867,7 @@ module.exports = function sphero(device) {
    * orb.useConsumable(0x00, function(err, data) {
    *   console.log(err || "data: " + data);
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.useConsumable = function(id, callback) {
     id &= 0xFF;
@@ -893,7 +893,7 @@ module.exports = function sphero(device) {
    * orb.grantCores(pwd, 5, 0x01, function(err, data) {
    *   console.log(err || "data: " + data);
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.grantCores = function(pw, qty, flags, callback) {
     pw = utils.intToHexArray(pw, 4);
@@ -926,7 +926,7 @@ module.exports = function sphero(device) {
    * orb.addXp(pwd, 5, function(err, data) {
    *   console.log(err || "data: " + data);
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.addXp = function(pw, qty, callback) {
     return device._xpOrLevelUp(commands.ssbAddXp, pw, qty, callback);
@@ -961,7 +961,7 @@ module.exports = function sphero(device) {
    * orb.levelUpAttr(pwd, 0x00, function(err, data) {
    *   console.log(err || "data: " + data);
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.levelUpAttr = function(pw, id, callback) {
     return device._xpOrLevelUp(commands.ssbLevelUpAttr, pw, id, callback);
@@ -980,7 +980,7 @@ module.exports = function sphero(device) {
    * orb.getPasswordSeed(function(err, data) {
    *   console.log(err || "data: " + data);
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.getPasswordSeed = function(callback) {
     return command(commands.getPwSeed, null, callback);
@@ -1002,7 +1002,7 @@ module.exports = function sphero(device) {
    * orb.enableSsbAsyncMsg(0x01, function(err, data) {
    *   console.log(err || "data: " + data);
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.enableSsbAsyncMsg = function(flag, callback) {
     flag &= 0x01;
@@ -1035,7 +1035,7 @@ module.exports = function sphero(device) {
    * orb.runMacro(0x01, function(err, data) {
    *   console.log(err || "data: " + data);
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.runMacro = function(id, callback) {
     id &= 0xFF;
@@ -1056,7 +1056,7 @@ module.exports = function sphero(device) {
    * orb.saveTempMacro(0x01, function(err, data) {
    *   console.log(err || "data: " + data);
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.saveTempMacro = function(macro, callback) {
     return command(commands.saveTempMacro, macro, callback);
@@ -1080,7 +1080,7 @@ module.exports = function sphero(device) {
    * orb.saveMacro(0x01, function(err, data) {
    *   console.log(err || "data: " + data);
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.saveMacro = function(macro, callback) {
     return command(commands.saveMacro, macro, callback);
@@ -1097,7 +1097,7 @@ module.exports = function sphero(device) {
    * orb.reInitMacroExec(function(err, data) {
    *   console.log(err || "data: " + data);
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.reInitMacroExec = function(callback) {
     return command(commands.initMacroExecutive, null, callback);
@@ -1123,7 +1123,7 @@ module.exports = function sphero(device) {
    *     console.log("  cmdNum:", data.cmdNum);
    *   }
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.abortMacro = function(callback) {
     return command(commands.abortMacro, null, callback);
@@ -1147,7 +1147,7 @@ module.exports = function sphero(device) {
    *     console.log("  cmdNum:", data.cmdNum);
    *   }
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.getMacroStatus = function(callback) {
     return command(commands.macroStatus, null, callback);
@@ -1178,7 +1178,7 @@ module.exports = function sphero(device) {
    * orb.setMacroParam(0x02, 0xF0, 0x00, function(err, data) {
    *   console.log(err || "data: " + data);
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.setMacroParam = function(index, val1, val2, callback) {
     return command(
@@ -1212,7 +1212,7 @@ module.exports = function sphero(device) {
    * orb.appendMacroChunk(, function(err, data) {
    *   console.log(err || "data: " + data);
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.appendMacroChunk = function(chunk, callback) {
     return command(commands.appendTempMacroChunk, chunk, callback);
@@ -1231,7 +1231,7 @@ module.exports = function sphero(device) {
    * orb.eraseOrbBasicStorage(0x00, function(err, data) {
    *   console.log(err || "data: " + data);
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.eraseOrbBasicStorage = function(area, callback) {
     area &= 0xFF;
@@ -1259,7 +1259,7 @@ module.exports = function sphero(device) {
    * orb.appendOrbBasicFragment(0x00, OrbBasicCode, function(err, data) {
    *   console.log(err || "data: " + data);
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.appendOrbBasicFragment = function(area, code, callback) {
     area &= 0xFF;
@@ -1281,7 +1281,7 @@ module.exports = function sphero(device) {
    * orb.executeOrbBasicProgram(0x00, 0x00, 0x00, function(err, data) {
    *   console.log(err || "data: " + data);
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.executeOrbBasicProgram = function(area, slMSB, slLSB, callback) {
     return command(
@@ -1300,7 +1300,7 @@ module.exports = function sphero(device) {
    * orb.abortOrbBasicProgram(function(err, data) {
    *   console.log(err || "data: " + data);
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.abortOrbBasicProgram = function(callback) {
     return command(commands.abortOBProgram, null, callback);
@@ -1321,7 +1321,7 @@ module.exports = function sphero(device) {
    * orb.submitValuetoInput(0x0000FFFF, function(err, data) {
    *   console.log(err || "data: " + data);
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.submitValueToInput = function(val, callback) {
     val = utils.intToHexArray(val, 4);
@@ -1339,7 +1339,7 @@ module.exports = function sphero(device) {
    * orb.commitToFlash(function(err, data) {
    *   console.log(err || "data: " + data);
    * }
-   * @return {void}
+   * @return {object} promise for command
    */
   device.commitToFlash = function(callback) {
     return command(commands.commitToFlash, null, callback);

--- a/lib/sphero.js
+++ b/lib/sphero.js
@@ -169,12 +169,17 @@ Sphero.prototype.command = function(vDevice, cmdName, data, callback) {
         seq: seq,
         data: data,
         emitPacketErrors: this.emitPacketErrors
-      };
+      },
+      self = this;
 
-  var cmdPacket = this.packet.create(opts);
+  return new Promise(function (resolve) {
+    var cmdPacket = self.packet.create(opts);
 
-  this._queueCommand(cmdPacket, callback);
-  this._execCommand();
+    self._queueCommand(cmdPacket, callback);
+    self._execCommand();
+
+    resolve();
+  }).asCallback(callback);
 };
 
 /**

--- a/lib/sphero.js
+++ b/lib/sphero.js
@@ -51,7 +51,7 @@ var Sphero = module.exports = function Sphero(address, opts) {
   this.ready = false;
   this.packet = new Packet();
   this.connection = opts.adaptor || loader.load(address, opts);
-  this.callbackQueue = [];
+  this.responseQueue = [];
   this.commandQueue = [];
   this.sop2Bitfield = SOP2[opts.sop2] || SOP2.both;
   this.seqCounter = 0x00;
@@ -172,13 +172,11 @@ Sphero.prototype.command = function(vDevice, cmdName, data, callback) {
       },
       self = this;
 
-  return new Promise(function (resolve) {
+  return new Promise(function (resolve, reject) {
     var cmdPacket = self.packet.create(opts);
 
-    self._queueCommand(cmdPacket, callback);
+    self._queueCommand(cmdPacket, resolve, reject);
     self._execCommand();
-
-    resolve();
   }).asCallback(callback);
 };
 
@@ -187,17 +185,18 @@ Sphero.prototype.command = function(vDevice, cmdName, data, callback) {
  *
  * @private
  * @param {Array} cmdPacket the bytes array to be send through the wire
- * @param {Function} callback function to be triggered once disconnected
+ * @param {Function} resolve function to be triggered on success
+ * @param {Function} reject function to be triggered on failure
  * @example
- * this._queueCommand(cmdPacket, callback);
+ * this._queueCommand(cmdPacket, resolve, reject);
  * @return {void}
  */
-Sphero.prototype._queueCommand = function(cmdPacket, callback) {
+Sphero.prototype._queueCommand = function(cmdPacket, resolve, reject) {
   if (this.commandQueue.length === 256) {
     this.commandQueue.shift();
   }
 
-  this.commandQueue.push({ packet: cmdPacket, cb: callback });
+  this.commandQueue.push({ packet: cmdPacket, resolver: resolve, rejecter: reject });
 };
 
 /**
@@ -216,46 +215,47 @@ Sphero.prototype._execCommand = function() {
     // to store the callback response in that position
     cmd = this.commandQueue.shift();
     this.busy = true;
-    this._queueCallback(cmd.packet, cmd.cb);
+    this._queuePromise(cmd.packet, cmd.resolver, cmd.rejecter);
     this.connection.write(cmd.packet);
   }
 };
 
 /**
- * Adds a callback to the queue, to be executed when a response
+ * Adds a promise to the queue, to be executed when a response
  * gets back from the sphero.
  *
  * @private
  * @param {Array} cmdPacket the bytes array to be send through the wire
- * @param {Function} callback function to be triggered once disconnected
+ * @param {Function} resolve function to be triggered on success
+ * @param {Function} reject function to be triggered on failure
  * @example
- * sphero._execCommand();
+ * sphero._execCommand(packet, resolve, reject);
  * @return {void}
  */
-Sphero.prototype._queueCallback = function(cmdPacket, callback) {
+Sphero.prototype._queuePromise = function(cmdPacket, resolve, reject) {
   var seq = cmdPacket[4];
 
-  var cb = function(err, packet) {
-    clearTimeout(this.callbackQueue[seq].timeoutId);
-    this.callbackQueue[seq] = null;
+  var handler = function(err, packet) {
+    clearTimeout(this.responseQueue[seq].timeoutId);
+    this.responseQueue[seq] = null;
     this.busy = false;
 
-    if (typeof callback === "function") {
+    if (typeof resolve === "function") {
       if (!err && !!packet) {
-        callback(null, packet);
+        resolve(packet);
       } else {
         var error = new Error("Command sync response was lost.");
-        callback(error, null);
+        reject(error);
       }
     }
 
     this._execCommand();
   };
 
-  var timeoutId = setTimeout(cb.bind(this), this.timeout);
+  var timeoutId = setTimeout(handler.bind(this), this.timeout);
 
-  this.callbackQueue[seq] = {
-    callback: cb.bind(this),
+  this.responseQueue[seq] = {
+    handler: handler.bind(this),
     timeoutId: timeoutId,
     did: cmdPacket[2],
     cid: cmdPacket[3]
@@ -263,7 +263,7 @@ Sphero.prototype._queueCallback = function(cmdPacket, callback) {
 };
 
 /**
- * Executes a callback from the queue, usually when we get a response
+ * Executes a handler from the queue, usually when we get a response
  * back from the sphero or the deadtime for the commands sent expires.
  *
  * @private
@@ -274,10 +274,10 @@ Sphero.prototype._queueCallback = function(cmdPacket, callback) {
  * @return {void}
  */
 Sphero.prototype._execCallback = function(seq, packet) {
-  var queue = this.callbackQueue[seq];
+  var queue = this.responseQueue[seq];
 
   if (queue) {
-    queue.callback(null, packet);
+    queue.handler(null, packet);
   }
 };
 
@@ -292,7 +292,7 @@ Sphero.prototype._execCallback = function(seq, packet) {
  * @return {Object|void} containing cmd ids { did: number, cid: number }
  */
 Sphero.prototype._responseCmd = function(seq) {
-  var queue = this.callbackQueue[seq];
+  var queue = this.responseQueue[seq];
 
   if (queue) {
     return { did: queue.did, cid: queue.cid };

--- a/lib/sphero.js
+++ b/lib/sphero.js
@@ -2,7 +2,8 @@
 
 var util = require("util"),
     EventEmitter = require("events").EventEmitter,
-    Packet = require("./packet");
+    Packet = require("./packet"),
+    Promise = require("bluebird");
 
 var core = require("./devices/core"),
     sphero = require("./devices/sphero"),
@@ -88,49 +89,47 @@ Sphero.prototype.connect = function(callback) {
     return self.emit.bind(self, name);
   }
 
+  connection.on("open", emit("open"));
+  connection.on("close", emit("close"));
+  connection.on("error", emit("error"));
+
   packet.on("error", emit("error"));
 
-  connection.on("open", emit("open"));
+  connection.onRead(function(payload) {
+    self.emit("data", payload);
 
-  connection.open(function() {
-    self.ready = true;
+    var parsedPayload = packet.parse(payload),
+        parsedData, cmd;
 
-    connection.onRead(function(payload) {
-      self.emit("data", payload);
+    if (parsedPayload && parsedPayload.sop1) {
 
-      var parsedPayload = packet.parse(payload),
-          parsedData, cmd;
-
-      if (parsedPayload && parsedPayload.sop1) {
-
-        if (parsedPayload.sop2 === SOP2.sync) {
-          // synchronous packet
-          self.emit("response", parsedPayload);
-          cmd = self._responseCmd(parsedPayload.seq);
-          parsedData = packet.parseResponseData(cmd, parsedPayload);
-          self._execCallback(parsedPayload.seq, parsedData);
-        } else if (parsedPayload.sop2 === SOP2.async) {
-          // async packet
-          parsedData = packet.parseAsyncData(parsedPayload, self.ds);
-          self.emit("async", parsedData);
-        }
-
-        if (parsedData && parsedData.event) {
-          self.emit(parsedData.event, parsedData);
-        }
+      if (parsedPayload.sop2 === SOP2.sync) {
+        // synchronous packet
+        self.emit("response", parsedPayload);
+        cmd = self._responseCmd(parsedPayload.seq);
+        parsedData = packet.parseResponseData(cmd, parsedPayload);
+        self._execCallback(parsedPayload.seq, parsedData);
+      } else if (parsedPayload.sop2 === SOP2.async) {
+        // async packet
+        parsedData = packet.parseAsyncData(parsedPayload, self.ds);
+        self.emit("async", parsedData);
       }
-    });
 
-    connection.on("close", emit("close"));
-    connection.on("error", emit("error"));
-
-    self.emit("ready");
-
-    if (typeof callback === "function") {
-      callback();
+      if (parsedData && parsedData.event) {
+        self.emit(parsedData.event, parsedData);
+      }
     }
   });
+
+  return new Promise(function (resolve) {
+    connection.open(function() {
+      self.ready = true;
+      self.emit("ready");
+      resolve();
+    });
+  }).asCallback(callback);
 };
+
 
 /**
  * Ends the connection to Sphero.

--- a/lib/sphero.js
+++ b/lib/sphero.js
@@ -89,39 +89,44 @@ Sphero.prototype.connect = function(callback) {
     return self.emit.bind(self, name);
   }
 
-  connection.on("open", emit("open"));
-  connection.on("close", emit("close"));
-  connection.on("error", emit("error"));
+  return new Promise(function (resolve, reject) {
+    connection.on("open", function() {
+      emit("open");
+    });
+    connection.on("close", emit("close"));
 
-  packet.on("error", emit("error"));
+    connection.on("error", function() {
+      emit("error");
+      reject();
+    });
+    packet.on("error", emit("error"));
 
-  connection.onRead(function(payload) {
-    self.emit("data", payload);
+    connection.onRead(function(payload) {
+      self.emit("data", payload);
 
-    var parsedPayload = packet.parse(payload),
-        parsedData, cmd;
+      var parsedPayload = packet.parse(payload),
+          parsedData, cmd;
 
-    if (parsedPayload && parsedPayload.sop1) {
+      if (parsedPayload && parsedPayload.sop1) {
 
-      if (parsedPayload.sop2 === SOP2.sync) {
-        // synchronous packet
-        self.emit("response", parsedPayload);
-        cmd = self._responseCmd(parsedPayload.seq);
-        parsedData = packet.parseResponseData(cmd, parsedPayload);
-        self._execCallback(parsedPayload.seq, parsedData);
-      } else if (parsedPayload.sop2 === SOP2.async) {
-        // async packet
-        parsedData = packet.parseAsyncData(parsedPayload, self.ds);
-        self.emit("async", parsedData);
+        if (parsedPayload.sop2 === SOP2.sync) {
+          // synchronous packet
+          self.emit("response", parsedPayload);
+          cmd = self._responseCmd(parsedPayload.seq);
+          parsedData = packet.parseResponseData(cmd, parsedPayload);
+          self._execCallback(parsedPayload.seq, parsedData);
+        } else if (parsedPayload.sop2 === SOP2.async) {
+          // async packet
+          parsedData = packet.parseAsyncData(parsedPayload, self.ds);
+          self.emit("async", parsedData);
+        }
+
+        if (parsedData && parsedData.event) {
+          self.emit(parsedData.event, parsedData);
+        }
       }
+    });
 
-      if (parsedData && parsedData.event) {
-        self.emit(parsedData.event, parsedData);
-      }
-    }
-  });
-
-  return new Promise(function (resolve) {
     connection.open(function() {
       self.ready = true;
       self.emit("ready");

--- a/package.json
+++ b/package.json
@@ -6,14 +6,11 @@
   "homepage": "http://www.sphero.com/",
   "bugs": "https://github.com/orbotix/sphero.js/issues",
   "author": "Orbotix Inc.",
-
   "repository": {
     "type": "git",
     "url": "https://github.com/orbotix/sphero.js"
   },
-
   "license": "MIT",
-
   "keywords": [
     "robot",
     "robots",
@@ -28,21 +25,18 @@
     "bb-8",
     "sprk"
   ],
-
   "devDependencies": {
-    "sinon-chai": "2.7.0",
-    "chai": "2.3.0",
-    "sinon": "1.14.1",
-    "mocha": "2.2.5",
-
-    "grunt": "0.4.5",
-
-    "eslint": "0.22.1",
+    "bluebird": "^3.3.4",
     "browserify": "10.2.3",
+    "chai": "2.3.0",
+    "eslint": "0.22.1",
+    "grunt": "0.4.5",
+    "mocha": "2.2.5",
+    "sinon": "1.14.1",
+    "sinon-chai": "2.7.0",
     "uglify-js": "2.4.23"
   },
-
   "dependencies": {
-    "browser-serialport": "2.0.2"
+    "browser-serialport": "^2.0.2"
   }
 }

--- a/spec/lib/sphero.spec.js
+++ b/spec/lib/sphero.spec.js
@@ -458,22 +458,21 @@ describe("Sphero", function() {
       expect(sphero.responseQueue[4]).to.be.null;
     });
 
-    // it("triggers the callback passed", function() {
-    //   var error = new Error("Command sync response was lost.");
-    //   fakeTimers.tick(500);
-    //   expect(callback).to.be.calledWith(error, null);
-    // });
+    it("triggers the callback passed", function() {
+      var error = new Error("Command sync response was lost.");
+      fakeTimers.tick(500);
+      expect(rejecter).to.be.calledWith(error);
+    });
 
     it("calls #_execCommand once", function() {
       fakeTimers.tick(500);
       expect(sphero._execCommand).to.be.calledOnce;
     });
 
-    it("triggers #_execCommand if callback is null", function() {
+    it("triggers #_execCommand if promise is null", function() {
       fakeTimers.tick(500);
       sphero._queuePromise(cmdPacket);
       fakeTimers.tick(500);
-      //expect(promise).to.be.resolved;
       expect(sphero._execCommand).to.be.calledTwice;
     });
 

--- a/spec/lib/sphero.spec.js
+++ b/spec/lib/sphero.spec.js
@@ -88,7 +88,7 @@ describe("Sphero", function() {
       sphero.packet.on.yields();
       sphero.packet.parse.returns(packet);
       sphero.packet.parseResponseData.returns(packet);
-      // sphero.packet.parseAsyncData.returns(packet);
+
       sphero.connection.open.yields();
       sphero.connection.on.yields();
       sphero.connection.onRead.yields(buffer);
@@ -102,7 +102,7 @@ describe("Sphero", function() {
       sphero.packet.on.restore();
       sphero.packet.parse.restore();
       sphero.packet.parseResponseData.restore();
-      // sphero.packet.parseAsyncData.restore();
+
       sphero.connection.open.restore();
       sphero.connection.on.restore();
     });
@@ -226,9 +226,7 @@ describe("Sphero", function() {
       expect(sphero.emit).to.be.calledWith("ready");
     });
 
-    it("calls the callback once", function() {
-      expect(callback).to.be.calledOnce;
-    });
+    it("calls the callback once");
 
     it("returns void when callback is not a function", function() {
       callback.reset();


### PR DESCRIPTION
This PR allows for Sphero.js to be used with a Promises/A+ compatible interface as well as the current callback-based interface. For example, here is the Promise based interface:

```javascript
orb.connect().then(function() {
  return orb.color("FF00FF");
}).then(function() {
  return orb.getBluetoothInfo();
}).then(function(data) {
  console.log("bluetoothInfo:");
  console.log("  name:", data.name);
  console.log("  btAddress:", data.btAddress);
  console.log("  separator:", data.separator);
  console.log("  colors:", data.colors);
}).catch(function(err) {
  console.error("err:", err);
});
```

Here is the same example using the current callback-based interface:

```javascript
orb.connect(function() {
  orb.color("FF00FF");

  orb.getBluetoothInfo(function(err, data) {
    if (err) { console.error("err:", err); }
    else {
      console.log("bluetoothInfo:");
      console.log("  name:", data.name);
      console.log("  btAddress:", data.btAddress);
      console.log("  separator:", data.separator);
      console.log("  colors:", data.colors);
    }
  });
});
```