### PR TITLE
Fix BLE adaptor behavior when BLE bindings are already powered on

### DIFF
--- a/lib/adaptors/ble.js
+++ b/lib/adaptors/ble.js
@@ -90,13 +90,17 @@ Adaptor.prototype.open = function open(callback) {
       }
     });
 
-    ble.on("stateChange", function(state) {
-      if (state === "poweredOn") {
-        ble.startScanning();
-      } else {
-        ble.stopScanning();
-      }
-    });
+    if (ble.state === "poweredOn") {
+      ble.startScanning();
+    } else {
+      ble.on("stateChange", function(state) {
+        if (state === "poweredOn") {
+          ble.startScanning();
+        } else {
+          ble.stopScanning();
+        }
+      });
+    }
   }
 };
 


### PR DESCRIPTION
BLE scanning never starts if the BLE bindings are already powered on when the connection to the robot is requested. This PR fixes this problem. See https://github.com/sandeepmistry/noble/issues/309 for more info and a discussion with the author of noble about this issue.

Thank you for making sphero.js :)