### PR TITLE
Feature/enhance connection to multiple ble devices

### DIFF
--- a/lib/adaptors/ble.js
+++ b/lib/adaptors/ble.js
@@ -17,6 +17,7 @@ function initBLE() {
       console.error("Browser-based BLE interface is not yet supported.");
     } else {
       ble = require("noble");
+      spheros++;
     }
   } catch (error) {
     ble = null;

--- a/lib/adaptors/ble.js
+++ b/lib/adaptors/ble.js
@@ -5,8 +5,6 @@ var util = require("util"),
 
 var ble;
 
-var peripherals = 0;
-
 function initBLE() {
   var isChrome = typeof chrome !== "undefined";
 
@@ -17,7 +15,6 @@ function initBLE() {
       console.error("Browser-based BLE interface is not yet supported.");
     } else {
       ble = require("noble");
-      peripherals++;
     }
   } catch (error) {
     ble = null;
@@ -89,16 +86,11 @@ Adaptor.prototype.open = function open(callback) {
     ble.on("discover", function(peripheral) {
       if (peripheral.id === self.uuid) {
 
-          ble.stopScanning();
-          self._connectPeripheral(peripheral, function(){
-            
-            peripherals--;
-
-            if (peripherals > 0) {
-              ble.startScanning();
-            }
-            callback();
-          });
+        ble.stopScanning();
+        self._connectPeripheral(peripheral, function() {
+          ble.startScanning();
+          callback();
+        });
       }
     });
 

--- a/lib/adaptors/ble.js
+++ b/lib/adaptors/ble.js
@@ -5,7 +5,7 @@ var util = require("util"),
 
 var ble;
 
-var spheros = 0;
+var peripherals = 0;
 
 function initBLE() {
   var isChrome = typeof chrome !== "undefined";
@@ -17,7 +17,7 @@ function initBLE() {
       console.error("Browser-based BLE interface is not yet supported.");
     } else {
       ble = require("noble");
-      spheros++;
+      peripherals++;
     }
   } catch (error) {
     ble = null;
@@ -88,17 +88,17 @@ Adaptor.prototype.open = function open(callback) {
     // connect to peripheral using noble
     ble.on("discover", function(peripheral) {
       if (peripheral.id === self.uuid) {
-        spheros--;
-        
-        var _flagFindAllSpheros = setInterval(function() {
-          if (spheros === 0) {
-            clearInterval(_flagFindAllSpheros);
 
-            ble.stopScanning();
-            self._connectPeripheral(peripheral, callback);
+          ble.stopScanning();
+          self._connectPeripheral(peripheral, function(){
+            
+            peripherals--;
 
-          }
-        }, 100);
+            if (peripherals > 0) {
+              ble.startScanning();
+            }
+            callback();
+          });
       }
     });
 

--- a/lib/adaptors/ble.js
+++ b/lib/adaptors/ble.js
@@ -5,6 +5,8 @@ var util = require("util"),
 
 var ble;
 
+var spheros = 0;
+
 function initBLE() {
   var isChrome = typeof chrome !== "undefined";
 
@@ -85,8 +87,17 @@ Adaptor.prototype.open = function open(callback) {
     // connect to peripheral using noble
     ble.on("discover", function(peripheral) {
       if (peripheral.id === self.uuid) {
-        ble.stopScanning();
-        self._connectPeripheral(peripheral, callback);
+        spheros--;
+        
+        var _flagFindAllSpheros = setInterval(function() {
+          if (spheros === 0) {
+            clearInterval(_flagFindAllSpheros);
+
+            ble.stopScanning();
+            self._connectPeripheral(peripheral, callback);
+
+          }
+        }, 100);
       }
     });
 


### PR DESCRIPTION
# Problem
Some BLE adapters cannot connect to peripheral when in scanning mode. The following minimal script (not sphero related):

```
var noble = require('noble');
var os = require('os');

noble.on('stateChange', function(state) {
    console.log(state);
    if (state === 'poweredOn') {
        noble.startScanning();
    } else {
    }
});

noble.on('scanStart', function() {
    console.log('scanStart');
});

noble.on('scanStop', function() {
    console.log('scanStop');
});

noble.on('discover', function(peripheral) {

    var localName = peripheral.advertisement.localName;
    console.log("discover ", localName);

    if(localName !== undefined && localName !== "" && localName.substring(0, "BB-".length) === "BB-") {
        console.log("Connecting ", localName);

        peripheral.on('connect', function() {
            console.log(localName, 'connected');
        });

        peripheral.on('disconnect', function() {
            console.log(localName, 'disconnected');
        });

        // noble.stopScanning(); // Edit
        peripheral.connect(function(error) {
            if(error) {
                console.log(error);
                return;
            }
            console.log(localName, 'connected!'); 
            // noble.startScanning(); // Edit
        return;
        });
    }

});
```

... will cause the follwoing error messages: 

- Cambridge Silicon Radio, Ltd Bluetooth Dongle (HCI mode)) : `Error: Command disallowed`
- Intel Dual Band Wireless-AC 7260 (Intel Corporation Wireless 7260 (rev 73)) : `Error: Connection Rejected due to Limited Resources (0xd)`

See more at [noble](https://github.com/sandeepmistry/noble)'s [pull#638](https://github.com/sandeepmistry/noble/pull/638) or [issue#35](https://github.com/sandeepmistry/noble/issues/35)

Both yielding "noble warnings" with the sphero's [BLE adapter](https://github.com/orbotix/sphero.js/blob/master/lib/adaptors/ble.js) : `noble warning: unknown peripheral xxxxxxxxxxxx` (not always, depending when a connection is triggered).

# Solution
This pull request stops scanning before an attempt to connect, and, when conencted, initiate further scanning. Tested with both physical BLE adapters (mentioned above) and works reliable.

# Issue
Needs testing with other BLE stacks probably.