### PR TITLE
Bug/BLE packet parsing

### DIFF
--- a/lib/adaptors/ble.js
+++ b/lib/adaptors/ble.js
@@ -165,7 +165,7 @@ Adaptor.prototype.devModeOn = function(callback) {
                                function(e, c) {
           if (e) { return callback(e); }
           c.on("read", function(data) {
-            if (data && data.length > 5) {
+            if (data) {
               self.readHandler(data);
             }
           });

--- a/lib/packet.js
+++ b/lib/packet.js
@@ -105,15 +105,12 @@ Packet.prototype._checkIfInvalid = function(buffer) {
 
 Packet.prototype.parse = function(buffer) {
 
-  console.log("Received data", buffer);
-
   if (this._checkIfValid(buffer)) {
     // HACK: prevent having two valid packets
     // in buffer and only react on the most recent one
     // If received buffer is valid, compute
     // it and drop all previous
     this.partialBuffer = new Buffer(0);
-    console.log("Parse buffer", buffer);
     return this._parse(buffer);
   }
 
@@ -128,7 +125,6 @@ Packet.prototype.parse = function(buffer) {
   if (this._checkIfInvalid(buffer)) {
     // Drop if concatenation or received
     // fragment is clearly invalid
-    console.log("Discard buffer", buffer);
     this.partialBuffer = new Buffer(0);
     return null;
   }
@@ -136,7 +132,6 @@ Packet.prototype.parse = function(buffer) {
   if (this._checkIfValid(buffer)) {
     // Parse if valid, take care of
     // extra bytes within
-    console.log("Parse buffer", buffer);
     return this._parse(buffer);
   }
 

--- a/lib/packet.js
+++ b/lib/packet.js
@@ -69,31 +69,42 @@ Packet.prototype.create = function(opts) {
 };
 
 Packet.prototype.parse = function(buffer) {
+
+  //Todo: test for header before concat?
   if (this.partialBuffer.length > 0) {
     buffer = Buffer.concat(
       [this.partialBuffer, buffer],
-      buffer.length + this.partialBuffer.length
+      this.partialBuffer.length + buffer.length
     );
 
-    this.partialBuffer = new Buffer(0);
-  } else {
-    this.partialBuffer = new Buffer(buffer);
   }
 
-  if (this._checkSOPs(buffer)) {
-    // Check the packet is at least 6 bytes long
-    if (this._checkMinSize(buffer)) {
-      // Check the buffer length matches the
-      // DLEN value specified in the buffer
+
+  if (this._checkMinSize(buffer)) {
+    // Packet is at least 6 bytes long
+
+    if (this._checkSOPs(buffer)) {
+      // Packet has valid header
+
       if (this._checkExpectedSize(buffer) > -1) {
-        // If the packet looks good parse it
+        // If the buffer is at least of length 
+        // specified in the DLEN value of the buffer,
+        // try parsing, deal with extra bytes within 
+        // (e.g., put extra bytes in partial buffer)
         return this._parse(buffer);
       }
+
+    } else if (!this._checkSOPs(buffer)) {
+      // Discard packet of minimal size, 
+      // but without a valid header
+      this.partialBuffer = new Buffer(0);
+      return null;     
     }
 
-    this.partialBuffer = new Buffer(buffer);
   }
 
+  // Transfer too small packets 
+  this.partialBuffer = new Buffer(buffer);
   return null;
 };
 

--- a/lib/packet.js
+++ b/lib/packet.js
@@ -68,17 +68,7 @@ Packet.prototype.create = function(opts) {
   return packet;
 };
 
-Packet.prototype.parse = function(buffer) {
-
-  //Todo: test for header before concat?
-  if (this.partialBuffer.length > 0) {
-    buffer = Buffer.concat(
-      [this.partialBuffer, buffer],
-      this.partialBuffer.length + buffer.length
-    );
-
-  }
-
+Packet.prototype._checkIfValid = function(buffer) {
 
   if (this._checkMinSize(buffer)) {
     // Packet is at least 6 bytes long
@@ -87,25 +77,73 @@ Packet.prototype.parse = function(buffer) {
       // Packet has valid header
 
       if (this._checkExpectedSize(buffer) > -1) {
-        // If the buffer is at least of length 
-        // specified in the DLEN value of the buffer,
-        // try parsing, deal with extra bytes within 
-        // (e.g., put extra bytes in partial buffer)
-        return this._parse(buffer);
+        // If the buffer is at least of length
+        // specified in the DLEN value the buffer
+        // is valid (deal with extra bytes later)
+        return true;
       }
-
-    } else if (!this._checkSOPs(buffer)) {
-      // Discard packet of minimal size, 
-      // but without a valid header
-      this.partialBuffer = new Buffer(0);
-      return null;     
     }
-
   }
 
-  // Transfer too small packets 
+  return false;
+};
+
+Packet.prototype._checkIfInvalid = function(buffer) {
+
+  if (buffer.length >= 2) {
+
+    if (!this._checkSOPs(buffer)) {
+      // Discard packet of minimal size,
+      // but without a valid header
+      return true;
+    }
+  }
+
+  return false;
+
+};
+
+Packet.prototype.parse = function(buffer) {
+
+  console.log("Received data", buffer);
+
+  if (this._checkIfValid(buffer)) {
+    // HACK: prevent having two valid packets
+    // in buffer and only react on the most recent one
+    // If received buffer is valid, compute
+    // it and drop all previous
+    this.partialBuffer = new Buffer(0);
+    console.log("Parse buffer", buffer);
+    return this._parse(buffer);
+  }
+
+  if (this.partialBuffer.length > 0) {
+    // Concatenate with previous fragment
+    buffer = Buffer.concat(
+      [this.partialBuffer, buffer],
+      this.partialBuffer.length + buffer.length
+    );
+  }
+
+  if (this._checkIfInvalid(buffer)) {
+    // Drop if concatenation or received
+    // fragment is clearly invalid
+    console.log("Discard buffer", buffer);
+    this.partialBuffer = new Buffer(0);
+    return null;
+  }
+
+  if (this._checkIfValid(buffer)) {
+    // Parse if valid, take care of
+    // extra bytes within
+    console.log("Parse buffer", buffer);
+    return this._parse(buffer);
+  }
+
+  // Transfer too small packets to next step
   this.partialBuffer = new Buffer(buffer);
   return null;
+
 };
 
 Packet.prototype._parse = function(buffer) {


### PR DESCRIPTION
Running `bluez@5.45` and `node@v6.10.3` on Linux 4.11.6-3-ARCH #1 SMP PREEMPT Thu Jun 22 12:21:46 CEST 2017 x86_64 GNU/Linux.

# Issue 1
Almost only notable with collission detection, it can appear that almost all packages get lost. Collsion detection is mostly then not working at all.

# Cause

A typical collsiion detection package could have 17 bytes, which can get split over two BLE packages like this:

	$ btmon
	> ACL Data RX: Handle 3585 flags 0x02 dlen 27              #137 [hci0] 5.921519
      ATT: Handle Value Notification (0x1b) len 22
        Handle: 0x0010
          Data: fffe070011006afc3e0000020016002200000193
	> ACL Data RX: Handle 3585 flags 0x02 dlen 9               #138 [hci0] 5.922144
      ATT: Handle Value Notification (0x1b) len 4
        Handle: 0x0010
          Data: c8ad

At two positions it is assuemd that package size is at least 6 bytes (https://github.com/orbotix/sphero.js/blob/master/lib/adaptors/ble.js#L168 and https://github.com/orbotix/sphero.js/blob/master/lib/packet.js#L85)

The last two bytes get eaten and instead, another valid package got attached. and will become invalid making the whole collision detection inapplicable.

# Solution
Except all package length and use a different parsing idea https://github.com/orbotix/sphero.js/blob/master/lib/packet.js#L71. 

Basically, the core still remains with the "checkIfValid" function. However, smaller packets get stored for further use. Thus, a new function is needed checking whether a small package / concatenated package is for sure invalid.  

For example, the inital sync has for some reason the package 753e to offer, which get's dropped.

```
$ btmon 
> ACL Data RX: Handle 3585 flags 0x02 dlen 5              #111 [hci0] 28.345319
      ATT: Write Response (0x13) len 0
> ACL Data RX: Handle 3585 flags 0x02 dlen 9              #112 [hci0] 28.345912
      ATT: Handle Value Notification (0x1b) len 4
        Handle: 0x0010
          Data: 753e
< ACL Data TX: Handle 3585 flags 0x00 dlen 20             #113 [hci0] 28.352661
      ATT: Write Command (0x52) len 15
        Handle: 0x000e
          Data: ffff0212000701202020200162
> HCI Event: Number of Completed Packets (0x13) plen 5    #114 [hci0] 28.361244
        Num handles: 1
        Handle: 3585
        Count: 1
> ACL Data RX: Handle 3585 flags 0x02 dlen 13             #115 [hci0] 28.390439
      ATT: Handle Value Notification (0x1b) len 8
        Handle: 0x0010
          Data: ffff000001fe

```

# Issue 2

Two sync responses are possible in one BLE package:

`ff ff 00 42 01 bc ff ff 00 43 01 bb`

Computing the first package and only compute the rest bytes in a different response results in a chain of sync losses making the `collsion detection` stuck.

# Solution 2
If the received buffer is valid (as in the old `parse` method) compute this and drop the temporal buffer. Thus, only one sync loss appears. From what I can see, it needs changes in the whole parsing infrastructure to implement a clean solution.
