### PR TITLE
Refactored serialport adaptor to work with latest version of serialport

### DIFF
--- a/lib/adaptors/serialport.js
+++ b/lib/adaptors/serialport.js
@@ -52,7 +52,7 @@ util.inherits(Adaptor, EventEmitter);
  */
 Adaptor.prototype.open = function open(callback) {
   var self = this,
-      port = this.serialport = new serialport.SerialPort(this.conn, {});
+      port = this.serialport = new serialport(this.conn, {});
 
   function emit(name) {
     return self.emit.bind(self, name);


### PR DESCRIPTION
In the latest version of node-serialport, doing `require('serialport').SerialPort` is deprecated so Sphero.js does not work anymore. 
Instead, serialport should be required with only `require('serialport')` so I simply refactored the serialport.js file and it seems to be working fine now.
